### PR TITLE
Align issuer and jwks_uri in OIDC discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Align issuer and jwks_uri in OIDC discovery.
+
 ## [0.4.5] - 2022-06-01
 
 ### Fixed

--- a/pkg/oidc/discovery.go
+++ b/pkg/oidc/discovery.go
@@ -21,8 +21,8 @@ type DiscoveryResponse struct {
 func GenerateDiscoveryFile(bucketName, region string) (*bytes.Reader, error) {
 	// see https://github.com/aws/amazon-eks-pod-identity-webhook/blob/master/SELF_HOSTED_SETUP.md#create-the-oidc-discovery-and-keys-documents
 	v := DiscoveryResponse{
-		Issuer:                           fmt.Sprintf("https://%s.s3.%s.%s", bucketName, region, key.AWSEndpoint(region)),
-		JwksURI:                          fmt.Sprintf("https://%s.s3.%s.%s/keys.json", bucketName, region, key.AWSEndpoint(region)),
+		Issuer:                           fmt.Sprintf("https://s3.%s.%s/%s", region, key.AWSEndpoint(region), bucketName),
+		JwksURI:                          fmt.Sprintf("https://s3.%s.%s/%s/keys.json", region, key.AWSEndpoint(region), bucketName),
 		AuthorizationEndpoint:            "urn:kubernetes:programmatic_authorization",
 		ResponseTypesSupported:           []string{"id_token"},
 		SubjectTypesSupported:            []string{"public"},

--- a/pkg/oidc/discovery_test.go
+++ b/pkg/oidc/discovery_test.go
@@ -1,0 +1,51 @@
+package oidc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGenerateDiscoveryFile(t *testing.T) {
+	type args struct {
+		bucketName string
+		region     string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantIssuer  string
+		wantJWKSUri string
+		wantErr     bool
+	}{
+		{
+			name: "case 0",
+			args: args{
+				bucketName: "123456789012-g8s-test1-oidc-pod-identity",
+				region:     "eu-west-1",
+			},
+			wantIssuer:  "https://s3.eu-west-1.amazonaws.com/123456789012-g8s-test1-oidc-pod-identity",
+			wantJWKSUri: "https://s3.eu-west-1.amazonaws.com/123456789012-g8s-test1-oidc-pod-identity/keys.json",
+			wantErr:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GenerateDiscoveryFile(tt.args.bucketName, tt.args.region)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateDiscoveryFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			v := &DiscoveryResponse{}
+			if err = json.NewDecoder(got).Decode(&v); err != nil {
+				t.Errorf("cannot decode: %v", err)
+				return
+			}
+			if v.Issuer != tt.wantIssuer {
+				t.Errorf("Issuer = %v, want %v", v.Issuer, tt.wantIssuer)
+			}
+			if v.JwksURI != tt.wantJWKSUri {
+				t.Errorf("JwksURI = %v, want %v", v.JwksURI, tt.wantJWKSUri)
+			}
+		})
+	}
+}


### PR DESCRIPTION
One of our customer is facing issues when using azure pod identity webhook.
Issuer URL which is configured in the api server needs to be identical to the one in the OIDC discovery document.

```
 issuer URL which is configured in the api server is identical to the one in the OIDC discovery document
```

/cc @paurosello 

## Checklist

- [x] Update changelog in CHANGELOG.md.