### PR TITLE
Migrate IRSA v1 to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Handle migration from v1 to v2.
+
 ## [0.6.0] - 2022-08-17
 
 ### Changed

--- a/pkg/aws/interfaces.go
+++ b/pkg/aws/interfaces.go
@@ -28,6 +28,8 @@ type ClusterScoper interface {
 	ClusterNamespace() string
 	// Installation returns the installation name.
 	Installation() string
+	// MigrationNeeded checks if cluster needs migrated first.
+	MigrationNeeded() bool
 	// Region returns the AWS infrastructure cluster object region.
 	Region() string
 }

--- a/pkg/aws/scope/cluster.go
+++ b/pkg/aws/scope/cluster.go
@@ -26,6 +26,7 @@ type ClusterScopeParams struct {
 	ClusterNamespace string
 	ConfigName       string
 	Installation     string
+	Migration        bool
 	Region           string
 	ReleaseVersion   string
 	SecretName       string
@@ -99,6 +100,7 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 		clusterNamespace: params.ClusterNamespace,
 		configName:       params.ConfigName,
 		installation:     params.Installation,
+		migration:        params.Migration,
 		region:           params.Region,
 		releaseVersion:   params.ReleaseVersion,
 		secretName:       params.SecretName,
@@ -118,6 +120,7 @@ type ClusterScope struct {
 	clusterNamespace string
 	configName       string
 	installation     string
+	migration        bool
 	region           string
 	releaseVersion   string
 	secretName       string
@@ -138,7 +141,7 @@ func (s *ClusterScope) ARN() string {
 
 // BucketName returns the name of the OIDC S3 bucket.
 func (s *ClusterScope) BucketName() string {
-	if key.IsV18Release(s.Release()) {
+	if key.IsV18Release(s.Release()) || s.MigrationNeeded() {
 		return fmt.Sprintf("%s-v2", s.bucketName)
 	} else {
 		return s.bucketName
@@ -168,6 +171,11 @@ func (s *ClusterScope) ConfigName() string {
 // Installation returns the name of the installation where the cluster object is located.
 func (s *ClusterScope) Installation() string {
 	return s.installation
+}
+
+// MigrationNeeded returns if the cluster object needs migration beforehand.
+func (s *ClusterScope) MigrationNeeded() bool {
+	return s.migration
 }
 
 // Region returns the region of the AWS infrastructure cluster object.

--- a/pkg/aws/services/iam/oidc.go
+++ b/pkg/aws/services/iam/oidc.go
@@ -18,7 +18,7 @@ func (s *Service) CreateOIDCProvider(release *semver.Version, domain, bucketName
 	var identityProviderURL string
 
 	s3Endpoint := fmt.Sprintf("s3.%s.%s", region, key.AWSEndpoint(region))
-	if key.IsV18Release(release) && !key.IsChina(region) {
+	if (key.IsV18Release(release) && !key.IsChina(region)) || (s.scope.MigrationNeeded() && !key.IsChina(region)) {
 		identityProviderURL = fmt.Sprintf("https://%s", domain)
 	} else {
 		identityProviderURL = fmt.Sprintf("https://%s/%s", s3Endpoint, bucketName)
@@ -53,7 +53,7 @@ func (s *Service) CreateOIDCProvider(release *semver.Version, domain, bucketName
 
 func (s *Service) CreateOIDCTags(release *semver.Version, cfDomain, accountID, bucketName, region string, customerTags map[string]string) error {
 	var providerArn string
-	if key.IsV18Release(release) && !key.IsChina(region) {
+	if (key.IsV18Release(release) && !key.IsChina(region)) || (s.scope.MigrationNeeded() && !key.IsChina(region)) {
 		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/%s", key.ARNPrefix(region), accountID, cfDomain)
 	} else {
 		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/s3.%s.%s/%s", key.ARNPrefix(region), accountID, region, key.AWSEndpoint(region), bucketName)
@@ -94,7 +94,7 @@ func (s *Service) CreateOIDCTags(release *semver.Version, cfDomain, accountID, b
 
 func (s *Service) ListCustomerOIDCTags(release *semver.Version, cfDomain, accountID, bucketName, region string) (map[string]string, error) {
 	var providerArn string
-	if key.IsV18Release(release) && !key.IsChina(region) {
+	if (key.IsV18Release(release) && !key.IsChina(region)) || (s.scope.MigrationNeeded() && !key.IsChina(region)) {
 		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/%s", key.ARNPrefix(region), accountID, cfDomain)
 	} else {
 		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/s3.%s.%s/%s", key.ARNPrefix(region), accountID, region, key.AWSEndpoint(region), bucketName)
@@ -121,7 +121,7 @@ func (s *Service) ListCustomerOIDCTags(release *semver.Version, cfDomain, accoun
 
 func (s *Service) RemoveOIDCTags(release *semver.Version, cfDomain, accountID, bucketName, region string, tagKeys []string) error {
 	var providerArn string
-	if key.IsV18Release(release) && !key.IsChina(region) {
+	if (key.IsV18Release(release) && !key.IsChina(region)) || (s.scope.MigrationNeeded() && !key.IsChina(region)) {
 		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/%s", key.ARNPrefix(region), accountID, cfDomain)
 	} else {
 		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/s3.%s.%s/%s", key.ARNPrefix(region), accountID, region, key.AWSEndpoint(region), bucketName)
@@ -145,7 +145,7 @@ func (s *Service) RemoveOIDCTags(release *semver.Version, cfDomain, accountID, b
 
 func (s *Service) DeleteOIDCProvider(release *semver.Version, cfDomain, accountID, bucketName, region string) error {
 	var providerArn string
-	if key.IsV18Release(release) && !key.IsChina(region) {
+	if (key.IsV18Release(release) && !key.IsChina(region)) || (s.scope.MigrationNeeded() && !key.IsChina(region)) {
 		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/%s", key.ARNPrefix(region), accountID, cfDomain)
 	} else {
 		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/s3.%s.%s/%s", key.ARNPrefix(region), accountID, region, key.AWSEndpoint(region), bucketName)

--- a/pkg/aws/services/s3/object.go
+++ b/pkg/aws/services/s3/object.go
@@ -26,7 +26,7 @@ type FileObject struct {
 }
 
 func (s *Service) UploadFiles(release *semver.Version, domain, bucketName string, privateKey *rsa.PrivateKey) error {
-	discoveryFile, err := oidc2.GenerateDiscoveryFile(release, domain, bucketName, s.scope.Region())
+	discoveryFile, err := oidc2.GenerateDiscoveryFile(release, domain, bucketName, s.scope.Region(), s.scope.MigrationNeeded())
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -84,7 +84,7 @@ func (s *Service) UploadFiles(release *semver.Version, domain, bucketName string
 				Body: &content,
 			}
 
-			if key.IsV18Release(release) && !key.IsChina(s.scope.Region()) {
+			if (key.IsV18Release(release) && !key.IsChina(s.scope.Region())) || (s.scope.MigrationNeeded() && !key.IsChina(s.scope.Region())) {
 				input.ACL = aws.String("private")
 			}
 			_, err = s.Client.PutObject(&input)

--- a/pkg/irsa/irsa.go
+++ b/pkg/irsa/irsa.go
@@ -143,7 +143,7 @@ func (s *IRSAService) Reconcile(ctx context.Context) error {
 	}
 
 	// only restrict access when IRSA is used via Cloudfront in v18 and non-China region
-	if !key.IsChina(s.Scope.Region()) && key.IsV18Release(s.Scope.Release()) {
+	if (!key.IsChina(s.Scope.Region()) && key.IsV18Release(s.Scope.Release())) || (s.Scope.MigrationNeeded() && !key.IsChina(s.Scope.Region())) {
 		err = s.S3.BlockPublicAccess(s.Scope.BucketName())
 		if err != nil {
 			s.Scope.Logger.Error(err, "failed to block public access")
@@ -152,7 +152,7 @@ func (s *IRSAService) Reconcile(ctx context.Context) error {
 	}
 
 	// Cloudfront only for non-China region and v18.x.x release or higher
-	if !key.IsChina(s.Scope.Region()) && key.IsV18Release(s.Scope.Release()) {
+	if !key.IsChina(s.Scope.Region()) && key.IsV18Release(s.Scope.Release()) || (s.Scope.MigrationNeeded() && !key.IsChina(s.Scope.Region())) {
 		distribution, err := s.Cloudfront.CreateDistribution(s.Scope.AccountID(), customerTags)
 		if err != nil {
 			ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Inc()
@@ -212,7 +212,7 @@ func (s *IRSAService) Reconcile(ctx context.Context) error {
 	}
 
 	// restrict access only for non-China region and v18.x.x release or higher
-	if !key.IsChina(s.Scope.Region()) && key.IsV18Release(s.Scope.Release()) {
+	if (!key.IsChina(s.Scope.Region()) && key.IsV18Release(s.Scope.Release())) || (s.Scope.MigrationNeeded() && !key.IsChina(s.Scope.Region())) {
 		uploadPolicy := func() error { return s.S3.UpdatePolicy(s.Scope.BucketName(), cfOaiId) }
 		err = backoff.Retry(uploadPolicy, b)
 		if err != nil {
@@ -221,7 +221,7 @@ func (s *IRSAService) Reconcile(ctx context.Context) error {
 		}
 	}
 	// restrict access only for non-China region and v18.x.x release or higher
-	if !key.IsChina(s.Scope.Region()) && key.IsV18Release(s.Scope.Release()) {
+	if (!key.IsChina(s.Scope.Region()) && key.IsV18Release(s.Scope.Release())) || (s.Scope.MigrationNeeded() && !key.IsChina(s.Scope.Region())) {
 		err = s.S3.BlockPublicAccess(s.Scope.BucketName())
 		if err != nil {
 			s.Scope.Logger.Error(err, "failed to block public access")
@@ -286,7 +286,7 @@ func (s *IRSAService) Delete(ctx context.Context) error {
 	var cfOriginAccessIdentityId string
 	cfConfig := &v1.ConfigMap{}
 
-	if !key.IsChina(s.Scope.Region()) && key.IsV18Release(s.Scope.Release()) {
+	if (!key.IsChina(s.Scope.Region()) && key.IsV18Release(s.Scope.Release())) || (s.Scope.MigrationNeeded() && !key.IsChina(s.Scope.Region())) {
 		err = s.Client.Get(ctx, types.NamespacedName{Namespace: s.Scope.ClusterNamespace(), Name: s.Scope.ConfigName()}, cfConfig)
 		if apierrors.IsNotFound(err) {
 			s.Scope.Logger.Info("Configmap for OIDC cloudfront does not exist anymore, skipping")
@@ -325,7 +325,7 @@ func (s *IRSAService) Delete(ctx context.Context) error {
 		return err
 	}
 
-	if !key.IsChina(s.Scope.Region()) && key.IsV18Release(s.Scope.Release()) {
+	if (!key.IsChina(s.Scope.Region()) && key.IsV18Release(s.Scope.Release())) || (s.Scope.MigrationNeeded() && !key.IsChina(s.Scope.Region())) {
 		err = s.Cloudfront.DisableDistribution(cfDistributionId)
 		if err != nil {
 			s.Scope.Logger.Error(err, "failed to disable cloudfront distribution for cluster")

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -28,10 +28,6 @@ const (
 	V18AlphaRelease = "18.0.0-alpha1"
 )
 
-var (
-	migrationClusters = []string{}
-)
-
 func BucketName(accountID, clusterName string) string {
 	return fmt.Sprintf("%s-g8s-%s-oidc-pod-identity", accountID, clusterName)
 }
@@ -80,14 +76,5 @@ func ContainsFinalizer(s []string, str string) bool {
 		}
 	}
 
-	return false
-}
-
-func NeedsMigration(cluster string, migrationClusters []string) bool {
-	for _, migrationCluster := range migrationClusters {
-		if migrationCluster == cluster {
-			return true
-		}
-	}
 	return false
 }

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -28,6 +28,10 @@ const (
 	V18AlphaRelease = "18.0.0-alpha1"
 )
 
+var (
+	migrationClusters = []string{}
+)
+
 func BucketName(accountID, clusterName string) string {
 	return fmt.Sprintf("%s-g8s-%s-oidc-pod-identity", accountID, clusterName)
 }
@@ -76,5 +80,14 @@ func ContainsFinalizer(s []string, str string) bool {
 		}
 	}
 
+	return false
+}
+
+func NeedsMigration(cluster string, migrationClusters []string) bool {
+	for _, migrationCluster := range migrationClusters {
+		if migrationCluster == cluster {
+			return true
+		}
+	}
 	return false
 }

--- a/pkg/oidc/discovery.go
+++ b/pkg/oidc/discovery.go
@@ -20,7 +20,7 @@ type DiscoveryResponse struct {
 	ClaimsSupported                  []string `json:"claims_supported"`
 }
 
-func GenerateDiscoveryFile(release *semver.Version, domain, bucketName, region string) (*bytes.Reader, error) {
+func GenerateDiscoveryFile(release *semver.Version, domain, bucketName, region string, migrationNeeded bool) (*bytes.Reader, error) {
 	// see https://github.com/aws/amazon-eks-pod-identity-webhook/blob/master/SELF_HOSTED_SETUP.md#create-the-oidc-discovery-and-keys-documents
 	v := DiscoveryResponse{
 		AuthorizationEndpoint:            "urn:kubernetes:programmatic_authorization",
@@ -29,7 +29,7 @@ func GenerateDiscoveryFile(release *semver.Version, domain, bucketName, region s
 		IDTokenSigningAlgValuesSupported: []string{"RS256"},
 		ClaimsSupported:                  []string{"sub", "iss"},
 	}
-	if key.IsV18Release(release) && !key.IsChina(region) {
+	if (key.IsV18Release(release) && !key.IsChina(region)) || (migrationNeeded && !key.IsChina(region)) {
 		// Cloudfront
 		v.Issuer = fmt.Sprintf("https://%s", domain)
 		v.JwksURI = fmt.Sprintf("https://%s/keys.json", domain)

--- a/pkg/oidc/discovery_test.go
+++ b/pkg/oidc/discovery_test.go
@@ -35,7 +35,7 @@ func TestGenerateDiscoveryFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			release, _ := semver.New("18.0.0")
-			got, err := GenerateDiscoveryFile(release, tt.args.domain, tt.args.bucketName, tt.args.region)
+			got, err := GenerateDiscoveryFile(release, tt.args.domain, tt.args.bucketName, tt.args.region, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GenerateDiscoveryFile() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Existing IRSA clusters should be handled carefully. When migrating from v17.x.x to v18.x.x we make some big changes. Therefore we must add the cluster id in configmap `giantswarm/irsa-migration` (create if doesn't exist yet) before customer upgrades. This will allow customer to use cloudfront domain and adjust the IAM roles with the new trust entity.

Example of configmap:

```
apiVersion: v1
kind: ConfigMap
metadata:
  creationTimestamp: 2016-02-18T18:52:05Z
  name: irsa-migration
  namespace: giantswarm
data:
  n3tx7: "true"
...
```

Once cluster is added irsa-operator will create all new components beforehand without breaking things.

Customer can grab CF domain from `CLUSTER_ID-irsa-cloudfront` config map in org namespace on MC's and add the trust entity to IAM roles. This will give them a smooth experience.

## Checklist

- [x] Update changelog in CHANGELOG.md.