### PR TITLE
Fix unsupported strings.Title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Check if Cloudfront Distribution is empty.
+- Unsupported `strings.Title`.
 
 ## [0.8.3] - 2022-10-28
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/peak/s3hash v0.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
+	golang.org/x/text v0.3.7
 	gopkg.in/square/go-jose.v2 v2.5.1
 	k8s.io/api v0.23.2
 	k8s.io/apimachinery v0.23.2
@@ -72,7 +73,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
-	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/pkg/util/record/recorder.go
+++ b/pkg/util/record/recorder.go
@@ -2,9 +2,10 @@
 package record
 
 import (
-	"strings"
 	"sync"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -29,20 +30,20 @@ func InitFromRecorder(recorder record.EventRecorder) {
 
 // Event constructs an event from the given information and puts it in the queue for sending.
 func Event(object runtime.Object, reason, message string) {
-	defaultRecorder.Event(object, corev1.EventTypeNormal, strings.Title(reason), message)
+	defaultRecorder.Event(object, corev1.EventTypeNormal, cases.Title(language.English, cases.NoLower).String(reason), message)
 }
 
 // Eventf is just like Event, but with Sprintf for the message field.
 func Eventf(object runtime.Object, reason, message string, args ...interface{}) {
-	defaultRecorder.Eventf(object, corev1.EventTypeNormal, strings.Title(reason), message, args...)
+	defaultRecorder.Eventf(object, corev1.EventTypeNormal, cases.Title(language.English, cases.NoLower).String(reason), message, args...)
 }
 
 // Warn constructs a warning event from the given information and puts it in the queue for sending.
 func Warn(object runtime.Object, reason, message string) {
-	defaultRecorder.Event(object, corev1.EventTypeWarning, strings.Title(reason), message)
+	defaultRecorder.Event(object, corev1.EventTypeWarning, cases.Title(language.English, cases.NoLower).String(reason), message)
 }
 
 // Warnf is just like Warn, but with Sprintf for the message field.
 func Warnf(object runtime.Object, reason, message string, args ...interface{}) {
-	defaultRecorder.Eventf(object, corev1.EventTypeWarning, strings.Title(reason), message, args...)
+	defaultRecorder.Eventf(object, corev1.EventTypeWarning, cases.Title(language.English, cases.NoLower).String(reason), message, args...)
 }


### PR DESCRIPTION
```
SA1019: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead.
```

## Checklist

- [x] Update changelog in CHANGELOG.md.