### PR TITLE
improve OIDC provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve `oidc` service in order to recreate the OIDC provider on AWS when any config is changed.
+
 ## [0.8.4] - 2022-11-02
 
 ### Fixed

--- a/pkg/aws/services/iam/oidc.go
+++ b/pkg/aws/services/iam/oidc.go
@@ -28,14 +28,14 @@ func (s *Service) EnsureOIDCProvider(identityProviderURL, clientID string) error
 
 	if existing != nil {
 		// Check if values are up to date.
-		if *existing.Url != identityProviderURL ||
-			len(existing.ThumbprintList) != 1 || *existing.ThumbprintList[0] != tp ||
+		if fmt.Sprintf("https://%s", *existing.Url) != identityProviderURL ||
+			len(existing.ThumbprintList) != 1 || strings.ToLower(*existing.ThumbprintList[0]) != strings.ToLower(tp) ||
 			len(existing.ClientIDList) != 1 || *existing.ClientIDList[0] != clientID {
 
 			if fmt.Sprintf("https://%s", *existing.Url) != identityProviderURL {
 				fmt.Printf("url changed: was 'https://%s', want '%s'\n", *existing.Url, identityProviderURL)
 			}
-			if len(existing.ThumbprintList) != 1 || *existing.ThumbprintList[0] != tp {
+			if len(existing.ThumbprintList) != 1 || strings.ToLower(*existing.ThumbprintList[0]) != strings.ToLower(tp) {
 				fmt.Printf("tp changed. was '%s' want '%s'\n", *existing.ThumbprintList[0], tp)
 			}
 			if len(existing.ClientIDList) != 1 || *existing.ClientIDList[0] != clientID {

--- a/pkg/aws/services/iam/oidc.go
+++ b/pkg/aws/services/iam/oidc.go
@@ -32,11 +32,11 @@ func (s *Service) EnsureOIDCProvider(identityProviderURL, clientID string) error
 			len(existing.ThumbprintList) != 1 || *existing.ThumbprintList[0] != tp ||
 			len(existing.ClientIDList) != 1 || *existing.ClientIDList[0] != clientID {
 
-			if *existing.Url != identityProviderURL {
-				fmt.Printf("url changed: was %q, is %q", *existing.Url, identityProviderURL)
+			if fmt.Sprintf("https://%s", *existing.Url) != identityProviderURL {
+				fmt.Printf("url changed: was 'https://%s', want '%s'\n", *existing.Url, identityProviderURL)
 			}
 			if len(existing.ThumbprintList) != 1 || *existing.ThumbprintList[0] != tp {
-				fmt.Println("tp changed")
+				fmt.Printf("tp changed. was '%s' want '%s'\n", *existing.ThumbprintList[0], tp)
 			}
 			if len(existing.ClientIDList) != 1 || *existing.ClientIDList[0] != clientID {
 				fmt.Println("ClientID changed")

--- a/pkg/aws/services/iam/oidc.go
+++ b/pkg/aws/services/iam/oidc.go
@@ -29,13 +29,13 @@ func (s *Service) EnsureOIDCProvider(identityProviderURL, clientID string) error
 	if existing != nil {
 		// Check if values are up to date.
 		if fmt.Sprintf("https://%s", *existing.Url) != identityProviderURL ||
-			len(existing.ThumbprintList) != 1 || strings.ToLower(*existing.ThumbprintList[0]) != strings.ToLower(tp) ||
+			len(existing.ThumbprintList) != 1 || !strings.EqualFold(*existing.ThumbprintList[0], strings.ToLower(tp)) ||
 			len(existing.ClientIDList) != 1 || *existing.ClientIDList[0] != clientID {
 
 			if fmt.Sprintf("https://%s", *existing.Url) != identityProviderURL {
 				fmt.Printf("url changed: was 'https://%s', want '%s'\n", *existing.Url, identityProviderURL)
 			}
-			if len(existing.ThumbprintList) != 1 || strings.ToLower(*existing.ThumbprintList[0]) != strings.ToLower(tp) {
+			if len(existing.ThumbprintList) != 1 || !strings.EqualFold(*existing.ThumbprintList[0], strings.ToLower(tp)) {
 				fmt.Printf("tp changed. was '%s' want '%s'\n", *existing.ThumbprintList[0], tp)
 			}
 			if len(existing.ClientIDList) != 1 || *existing.ClientIDList[0] != clientID {

--- a/pkg/aws/services/iam/oidc.go
+++ b/pkg/aws/services/iam/oidc.go
@@ -32,16 +32,6 @@ func (s *Service) EnsureOIDCProvider(identityProviderURL, clientID string) error
 			len(existing.ThumbprintList) != 1 || !strings.EqualFold(*existing.ThumbprintList[0], strings.ToLower(tp)) ||
 			len(existing.ClientIDList) != 1 || *existing.ClientIDList[0] != clientID {
 
-			if fmt.Sprintf("https://%s", *existing.Url) != identityProviderURL {
-				fmt.Printf("url changed: was 'https://%s', want '%s'\n", *existing.Url, identityProviderURL)
-			}
-			if len(existing.ThumbprintList) != 1 || !strings.EqualFold(*existing.ThumbprintList[0], strings.ToLower(tp)) {
-				fmt.Printf("tp changed. was '%s' want '%s'\n", *existing.ThumbprintList[0], tp)
-			}
-			if len(existing.ClientIDList) != 1 || *existing.ClientIDList[0] != clientID {
-				fmt.Println("ClientID changed")
-			}
-
 			s.scope.Info("OIDCProvider needs to be replaced")
 			s.scope.Info("Deleting old OIDCProvider")
 			_, err = s.Client.DeleteOpenIDConnectProvider(&iam.DeleteOpenIDConnectProviderInput{OpenIDConnectProviderArn: aws.String(arn)})
@@ -50,7 +40,7 @@ func (s *Service) EnsureOIDCProvider(identityProviderURL, clientID string) error
 			}
 			s.scope.Info("Deleted old OIDCProvider")
 		} else {
-			s.scope.Info("OIDCProvider already exists")
+			s.scope.Info("OIDCProvider already exists and is up to date")
 			return nil
 		}
 	}

--- a/pkg/aws/services/iam/oidc.go
+++ b/pkg/aws/services/iam/oidc.go
@@ -8,13 +8,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/blang/semver"
+	"github.com/giantswarm/microerror"
 	"github.com/nhalstead/sprint"
 
 	"github.com/giantswarm/irsa-operator/pkg/key"
 	"github.com/giantswarm/irsa-operator/pkg/util"
 )
 
-func (s *Service) CreateOIDCProvider(release *semver.Version, domain, bucketName, region string) error {
+func (s *Service) EnsureOIDCProvider(release *semver.Version, domain, bucketName, region string) error {
 	var identityProviderURL string
 
 	s3Endpoint := fmt.Sprintf("s3.%s.%s", region, key.AWSEndpoint(region))
@@ -29,26 +30,91 @@ func (s *Service) CreateOIDCProvider(release *semver.Version, domain, bucketName
 		return err
 	}
 
+	arn, existing, err := s.findOIDCProvider()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if existing != nil {
+		// Check if values are up to date.
+		if *existing.Url != identityProviderURL ||
+			len(existing.ThumbprintList) != 1 || *existing.ThumbprintList[0] != tp ||
+			len(existing.ClientIDList) != 1 || *existing.ClientIDList[0] != fmt.Sprintf("sts.%s", key.AWSEndpoint(region)) {
+
+			if *existing.Url != identityProviderURL {
+				fmt.Printf("url changed: was %q, is %q", *existing.Url, identityProviderURL)
+			}
+			if len(existing.ThumbprintList) != 1 || *existing.ThumbprintList[0] != tp {
+				fmt.Println("tp changed")
+			}
+			if len(existing.ClientIDList) != 1 || *existing.ClientIDList[0] != fmt.Sprintf("sts.%s", key.AWSEndpoint(region)) {
+				fmt.Println("ClientID changed")
+			}
+
+			s.scope.Info("OIDCProvider needs to be replaced")
+			s.scope.Info("Deleting old OIDCProvider")
+			_, err = s.Client.DeleteOpenIDConnectProvider(&iam.DeleteOpenIDConnectProviderInput{OpenIDConnectProviderArn: aws.String(arn)})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			s.scope.Info("Deleted old OIDCProvider")
+		} else {
+			s.scope.Info("OIDCProvider already exists")
+			return nil
+		}
+	}
+
 	i := &iam.CreateOpenIDConnectProviderInput{
 		Url:            aws.String(identityProviderURL),
-		ThumbprintList: []*string{aws.String(removeColon(tp))},
+		ThumbprintList: []*string{aws.String(tp)},
 		ClientIDList:   []*string{aws.String(fmt.Sprintf("sts.%s", key.AWSEndpoint(region)))},
 	}
 
 	_, err = s.Client.CreateOpenIDConnectProvider(i)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case iam.ErrCodeEntityAlreadyExistsException:
-				s.scope.Info("OIDC provider already exists, skipping creation")
-				return nil
-			}
-		}
-		return err
+		return microerror.Mask(err)
 	}
 	s.scope.Info("Created OIDC provider")
 
 	return nil
+}
+
+func (s *Service) findOIDCProvider() (string, *iam.GetOpenIDConnectProviderOutput, error) {
+	s.scope.Info("Looking for existing OIDC provider")
+	output, err := s.Client.ListOpenIDConnectProviders(&iam.ListOpenIDConnectProvidersInput{})
+	if err != nil {
+		return "", nil, microerror.Mask(err)
+	}
+
+	for _, providerArn := range output.OpenIDConnectProviderList {
+		p, err := s.Client.GetOpenIDConnectProvider(&iam.GetOpenIDConnectProviderInput{
+			OpenIDConnectProviderArn: providerArn.Arn,
+		})
+		if err != nil {
+			return "", nil, microerror.Mask(err)
+		}
+
+		// Check if tags match
+		installationTagFound := false
+		clusterTagFound := false
+		for _, tag := range p.Tags {
+			if *tag.Key == key.S3TagInstallation && *tag.Value == s.scope.Installation() {
+				installationTagFound = true
+			}
+			if *tag.Key == key.S3TagCluster && *tag.Value == s.scope.ClusterName() {
+				clusterTagFound = true
+			}
+		}
+
+		if installationTagFound && clusterTagFound {
+			s.scope.Info("Found existing OIDC provider")
+			return *providerArn.Arn, p, nil
+		}
+	}
+
+	s.scope.Info("Did not find any OIDC provider")
+
+	return "", nil, nil
 }
 
 func (s *Service) CreateOIDCTags(release *semver.Version, cfDomain, accountID, bucketName, region string, customerTags map[string]string) error {
@@ -175,9 +241,5 @@ func caThumbPrint(ep string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fp.SHA1, nil
-}
-
-func removeColon(value string) string {
-	return strings.Replace(value, ":", "", -1)
+	return strings.Replace(fp.SHA1, ":", "", -1), nil
 }

--- a/pkg/aws/services/iam/oidc_test.go
+++ b/pkg/aws/services/iam/oidc_test.go
@@ -1,8 +1,0 @@
-package iam
-
-import "testing"
-
-func Test_caThumbPrint(t *testing.T) {
-	got, _ := caThumbPrint("d2oruhrymg2w9x.cloudfront.net")
-	t.Log(removeColon(got))
-}

--- a/pkg/irsa/capa/capa.go
+++ b/pkg/irsa/capa/capa.go
@@ -204,7 +204,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			identityProviderURL = fmt.Sprintf("https://%s/%s", s3Endpoint, s.Scope.BucketName())
 		}
 
-		return s.IAM.EnsureOIDCProvider(identityProviderURL, key.AWSEndpoint(s.Scope.Region()))
+		return s.IAM.EnsureOIDCProvider(identityProviderURL, key.STSUrl(s.Scope.Region()))
 	}
 	err = backoff.Retry(createOIDCProvider, b)
 	if err != nil {

--- a/pkg/irsa/capa/capa.go
+++ b/pkg/irsa/capa/capa.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"time"
 
 	"github.com/giantswarm/backoff"
@@ -195,7 +196,15 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	}
 
 	createOIDCProvider := func() error {
-		return s.IAM.EnsureOIDCProvider(s.Scope.Release(), cfDomain, s.Scope.BucketName(), s.Scope.Region())
+		var identityProviderURL string
+		s3Endpoint := fmt.Sprintf("s3.%s.%s", s.Scope.Region(), key.AWSEndpoint(s.Scope.Region()))
+		if (key.IsV18Release(s.Scope.Release()) && !key.IsChina(s.Scope.Region())) || (s.Scope.MigrationNeeded() && !key.IsChina(s.Scope.Region())) {
+			identityProviderURL = fmt.Sprintf("https://%s", cfDomain)
+		} else {
+			identityProviderURL = fmt.Sprintf("https://%s/%s", s3Endpoint, s.Scope.BucketName())
+		}
+
+		return s.IAM.EnsureOIDCProvider(identityProviderURL, key.AWSEndpoint(s.Scope.Region()))
 	}
 	err = backoff.Retry(createOIDCProvider, b)
 	if err != nil {

--- a/pkg/irsa/capa/capa.go
+++ b/pkg/irsa/capa/capa.go
@@ -195,7 +195,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	}
 
 	createOIDCProvider := func() error {
-		return s.IAM.CreateOIDCProvider(s.Scope.Release(), cfDomain, s.Scope.BucketName(), s.Scope.Region())
+		return s.IAM.EnsureOIDCProvider(s.Scope.Release(), cfDomain, s.Scope.BucketName(), s.Scope.Region())
 	}
 	err = backoff.Retry(createOIDCProvider, b)
 	if err != nil {

--- a/pkg/irsa/legacy/legacy.go
+++ b/pkg/irsa/legacy/legacy.go
@@ -197,7 +197,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			identityProviderURL = fmt.Sprintf("https://%s/%s", s3Endpoint, s.Scope.BucketName())
 		}
 
-		return s.IAM.EnsureOIDCProvider(identityProviderURL, key.AWSEndpoint(s.Scope.Region()))
+		return s.IAM.EnsureOIDCProvider(identityProviderURL, key.STSUrl(s.Scope.Region()))
 	}
 	n := func(err error, d time.Duration) {
 		s.Scope.Logger.Info("level", "warning", "message", fmt.Sprintf("retrying backoff in '%s' due to error", d.String()), "stack", fmt.Sprintf("%#v", err))

--- a/pkg/irsa/legacy/legacy.go
+++ b/pkg/irsa/legacy/legacy.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"time"
 
 	"github.com/giantswarm/backoff"

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -54,6 +54,10 @@ func AWSEndpoint(region string) string {
 	return awsEndpoint
 }
 
+func STSUrl(region string) string {
+	return fmt.Sprintf("sts.%s", AWSEndpoint(region))
+}
+
 func IsChina(region string) bool {
 	return strings.HasPrefix(region, "cn-")
 }


### PR DESCRIPTION
Before this PR, the `Identity Provider` was never checked for any externally-happened changes that needed to be reconciled.
For example, if I change the `Audience` in an existing IRSA `Identity provider`, it will stick and never be fixed by irsa-operator.

This PR adds a reconciliation-style behaviour that checks the main settings of the `Identity Provider` and ensures they have the correct value at every reconciliation loop.
This feature has the added benefit that we can change the desired settings of the Identity provider in the future and be sure they'll be applied.

## Checklist

- [x] Update changelog in CHANGELOG.md.
