### PR TITLE
Fix detection of v19 and v18 releases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `irsa-operator` to capa-app-collection.
 
+### Fixed
+
+- Fix detection of v19 and v18 releases.
+
 ## [0.8.4] - 2022-11-02
 
 ### Fixed

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -25,9 +25,6 @@ const (
 
 	CustomerTagLabel = "tag.provider.giantswarm.io/"
 	ReleaseLabel     = "release.giantswarm.io/version"
-
-	V18AlphaRelease = "18.0.0-alpha1"
-	V19AlphaRelease = "19.0.0-alpha1"
 )
 
 func BucketName(accountID, clusterName string) string {
@@ -71,13 +68,11 @@ func ARNPrefix(region string) string {
 }
 
 func IsV18Release(releaseVersion *semver.Version) bool {
-	v18AlphaVersion, _ := semver.New(V18AlphaRelease)
-	return releaseVersion.GE(*v18AlphaVersion)
+	return releaseVersion.Major >= 18
 }
 
 func IsV19Release(releaseVersion *semver.Version) bool {
-	v19, _ := semver.New(V19AlphaRelease)
-	return releaseVersion.GE(*v19)
+	return releaseVersion.Major >= 19
 }
 
 func ContainsFinalizer(s []string, str string) bool {


### PR DESCRIPTION
during e2e tests, the temporary release that's created is something like:

v19.0.0-123123123

according to semver this is < v19.0.0-alpha1, thus irsa operator does not kick in during e2e tests and the tests fail.

This PR changes cluster version detection in order to make it work with e2e tests

## Checklist

- [x] Update changelog in CHANGELOG.md.
