### PR TITLE
Add new service to handle route53 DNS records.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new service to handle route53 DNS records.
+
 ### Changed
 
 - Improve `oidc` service in order to recreate the OIDC provider on AWS when any config is changed.

--- a/pkg/aws/scope/clients.go
+++ b/pkg/aws/scope/clients.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/component-base/version"
@@ -29,6 +30,15 @@ func NewCloudfrontClient(session aws.Session, arn string, target runtime.Object)
 	CloudfrontClient.Handlers.Complete.PushBack(recordAWSPermissionsIssue(target))
 
 	return CloudfrontClient
+}
+
+// NewRoute53Client creates a new route53 API client for a given session
+func NewRoute53Client(session aws.Session, arn string, target runtime.Object) *route53.Route53 {
+	route53Client := route53.New(session.Session(), &awsclient.Config{Credentials: stscreds.NewCredentials(session.Session(), arn)})
+	route53Client.Handlers.Build.PushFrontNamed(getUserAgentHandler())
+	route53Client.Handlers.Complete.PushBack(recordAWSPermissionsIssue(target))
+
+	return route53Client
 }
 
 // NewS3Client creates a new S3 API client for a given session

--- a/pkg/aws/scope/types.go
+++ b/pkg/aws/scope/types.go
@@ -14,6 +14,11 @@ type IAMScope interface {
 	aws.ClusterScoper
 }
 
+// Route53Scope is a scope for use with the route53 reconciling service in cluster
+type Route53Scope interface {
+	aws.ClusterScoper
+}
+
 // S3Scope is a scope for use with the S3 reconciling service in cluster
 type S3Scope interface {
 	aws.ClusterScoper

--- a/pkg/aws/services/route53/error.go
+++ b/pkg/aws/services/route53/error.go
@@ -1,0 +1,7 @@
+package route53
+
+import "github.com/giantswarm/microerror"
+
+var zoneNotFoundError = &microerror.Error{
+	Kind: "zoneNotFoundError",
+}

--- a/pkg/aws/services/route53/route53.go
+++ b/pkg/aws/services/route53/route53.go
@@ -1,0 +1,68 @@
+package route53
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/giantswarm/microerror"
+)
+
+type CNAME struct {
+	Name  string
+	Value string
+}
+
+func (s *Service) FindHostedZone(basename string) (string, error) {
+	s.scope.Info("Searching route53 hosted zone ID")
+
+	output, err := s.Client.ListHostedZonesByName(&route53.ListHostedZonesByNameInput{
+		DNSName: aws.String(basename),
+	})
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	// We return the first public zone
+	for _, zone := range output.HostedZones {
+		if !*zone.Config.PrivateZone {
+			return *zone.Id, nil
+		}
+	}
+
+	return "", microerror.Mask(zoneNotFoundError)
+}
+
+func (s *Service) EnsureDNSRecord(hostedZoneID string, cname CNAME) error {
+	s.scope.Info(fmt.Sprintf("Ensuring CNAME record %q in zone %q", cname.Name, hostedZoneID))
+
+	input := &route53.ChangeResourceRecordSetsInput{
+		ChangeBatch: &route53.ChangeBatch{
+			Changes: []*route53.Change{
+				{
+					Action: aws.String(route53.ChangeActionUpsert),
+					ResourceRecordSet: &route53.ResourceRecordSet{
+						Name: aws.String(cname.Name),
+						ResourceRecords: []*route53.ResourceRecord{
+							{
+								Value: aws.String(cname.Value),
+							},
+						},
+						TTL:  aws.Int64(600),
+						Type: aws.String(route53.RRTypeCname),
+					},
+				},
+			},
+		},
+		HostedZoneId: aws.String(hostedZoneID),
+	}
+
+	_, err := s.Client.ChangeResourceRecordSets(input)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	s.scope.Info(fmt.Sprintf("Ensured CNAME record %q in zone %q", cname.Name, hostedZoneID))
+
+	return nil
+}

--- a/pkg/aws/services/route53/service.go
+++ b/pkg/aws/services/route53/service.go
@@ -1,0 +1,21 @@
+package route53
+
+import (
+	"github.com/aws/aws-sdk-go/service/route53/route53iface"
+
+	"github.com/giantswarm/irsa-operator/pkg/aws/scope"
+)
+
+// Service holds a collection of interfaces.
+type Service struct {
+	scope  scope.Route53Scope
+	Client route53iface.Route53API
+}
+
+// NewService returns a new service given the Cloudfront api client.
+func NewService(clusterScope scope.IAMScope) *Service {
+	return &Service{
+		scope:  clusterScope,
+		Client: scope.NewRoute53Client(clusterScope, clusterScope.ARN(), clusterScope.Cluster()),
+	}
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1546

This PR adds a new `route53` service that's still unused. It will be used in following PRs to create route53 records to be used as custom cloudfront domains.

## Checklist

- [x] Update changelog in CHANGELOG.md.
