### PR TITLE
Add new service to handle ACM certificates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add new service to handle route53 DNS records.
+- Add new service to handle ACM certificates.
 
 ### Changed
 

--- a/pkg/aws/scope/types.go
+++ b/pkg/aws/scope/types.go
@@ -4,6 +4,11 @@ import (
 	"github.com/giantswarm/irsa-operator/pkg/aws"
 )
 
+// ACMScope is a scope for use with the ACM reconciling service in cluster
+type ACMScope interface {
+	aws.ClusterScoper
+}
+
 // CloudfrontScope is a scope for use with the Cloudfront reconciling service in cluster
 type CloudfrontScope interface {
 	aws.ClusterScoper

--- a/pkg/aws/services/acm/acm.go
+++ b/pkg/aws/services/acm/acm.go
@@ -1,0 +1,179 @@
+package acm
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/irsa-operator/pkg/aws/services/route53"
+	"github.com/giantswarm/irsa-operator/pkg/key"
+	"github.com/giantswarm/irsa-operator/pkg/util"
+)
+
+func (s *Service) EnsureCertificate(customerTags map[string]string) (*string, error) {
+	domain := key.CloudFrontAlias(s.scope.ClusterName(), s.scope.Installation(), s.scope.Region())
+
+	s.scope.Info(fmt.Sprintf("Ensuring ACM certificate for domain %q", domain))
+
+	// Check if certificate exists
+	existing, err := s.findCertificateForDomain(domain)
+	if err != nil {
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	if existing != nil {
+		s.scope.Info("ACM certificate already exists")
+
+		return existing, nil
+	}
+
+	input := &acm.RequestCertificateInput{
+		DomainName: aws.String(domain),
+		Options:    &acm.CertificateOptions{},
+		Tags: []*acm.Tag{
+			{
+				Key:   aws.String(key.S3TagOrganization),
+				Value: aws.String(util.RemoveOrg(s.scope.ClusterNamespace())),
+			},
+			{
+				Key:   aws.String(key.S3TagCluster),
+				Value: aws.String(s.scope.ClusterName()),
+			},
+			{
+				Key:   aws.String(fmt.Sprintf(key.S3TagCloudProvider, s.scope.ClusterName())),
+				Value: aws.String("owned"),
+			},
+			{
+				Key:   aws.String(key.S3TagInstallation),
+				Value: aws.String(s.scope.Installation()),
+			},
+		},
+		ValidationMethod: aws.String(acm.ValidationMethodDns),
+	}
+
+	for k, v := range customerTags {
+		tag := &acm.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+		input.Tags = append(input.Tags, tag)
+	}
+
+	s.scope.Info("Creating ACM certificate")
+
+	output, err := s.Client.RequestCertificate(input)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	s.scope.Info("ACM certificate created successfully")
+	return output.CertificateArn, nil
+}
+
+func (s *Service) IsCertificateIssued(arn string) (bool, error) {
+	s.scope.Info("Checking status of ACM certificate")
+
+	output, err := s.Client.DescribeCertificate(&acm.DescribeCertificateInput{
+		CertificateArn: aws.String(arn),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return *output.Certificate.Status == acm.CertificateStatusIssued, nil
+}
+
+func (s *Service) IsValidated(arn string) (bool, error) {
+	output, err := s.Client.DescribeCertificate(&acm.DescribeCertificateInput{
+		CertificateArn: aws.String(arn),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return *output.Certificate.DomainValidationOptions[0].ValidationStatus == acm.DomainStatusSuccess, nil
+}
+
+func (s *Service) GetValidationCNAME(arn string) (*route53.CNAME, error) {
+	output, err := s.Client.DescribeCertificate(&acm.DescribeCertificateInput{
+		CertificateArn: aws.String(arn),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// If certificate is just created, validation data might be missing.
+	if len(output.Certificate.DomainValidationOptions) == 0 ||
+		output.Certificate.DomainValidationOptions[0].ResourceRecord == nil ||
+		output.Certificate.DomainValidationOptions[0].ResourceRecord.Name == nil ||
+		output.Certificate.DomainValidationOptions[0].ResourceRecord.Value == nil {
+		return nil, microerror.Mask(domainValidationDnsRecordNotFound)
+	}
+
+	return &route53.CNAME{
+		Name:  *output.Certificate.DomainValidationOptions[0].ResourceRecord.Name,
+		Value: *output.Certificate.DomainValidationOptions[0].ResourceRecord.Value,
+	}, nil
+}
+
+func (s *Service) DeleteCertificate() error {
+	s.scope.Info("Ensuring ACM certificate is deleted")
+	domain := key.CloudFrontAlias(s.scope.ClusterName(), s.scope.Installation(), s.scope.Region())
+
+	arn, err := s.findCertificateForDomain(domain)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if arn != nil {
+		s.scope.Info("Deleting ACM certificate")
+		_, err = s.Client.DeleteCertificate(&acm.DeleteCertificateInput{CertificateArn: arn})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		s.scope.Info("Deleted ACM certificate")
+		return nil
+	}
+
+	s.scope.Info("ACM certificate was not found")
+
+	return nil
+}
+
+func (s *Service) findCertificateForDomain(domain string) (*string, error) {
+	var existing *acm.ListCertificatesOutput
+	var err error
+
+	// NextToken is the way AWS API performs pagination over results.
+	// If NextToken is not nil, there is another page of results to be requested.
+	// If existing is nil, means we have to request the very first page of results.
+	for existing == nil || existing.NextToken != nil {
+		var nextToken *string
+		if existing != nil {
+			nextToken = existing.NextToken
+		}
+		existing, err = s.Client.ListCertificates(&acm.ListCertificatesInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		if len(existing.CertificateSummaryList) == 0 {
+			return nil, nil
+		}
+
+		for _, c := range existing.CertificateSummaryList {
+			if *c.DomainName == domain {
+				return c.CertificateArn, nil
+			}
+		}
+	}
+
+	return nil, nil
+}

--- a/pkg/aws/services/acm/acm.go
+++ b/pkg/aws/services/acm/acm.go
@@ -12,9 +12,7 @@ import (
 	"github.com/giantswarm/irsa-operator/pkg/util"
 )
 
-func (s *Service) EnsureCertificate(customerTags map[string]string) (*string, error) {
-	domain := key.CloudFrontAlias(s.scope.ClusterName(), s.scope.Installation(), s.scope.Region())
-
+func (s *Service) EnsureCertificate(domain string, customerTags map[string]string) (*string, error) {
 	s.scope.Info(fmt.Sprintf("Ensuring ACM certificate for domain %q", domain))
 
 	// Check if certificate exists
@@ -120,9 +118,8 @@ func (s *Service) GetValidationCNAME(arn string) (*route53.CNAME, error) {
 	}, nil
 }
 
-func (s *Service) DeleteCertificate() error {
+func (s *Service) DeleteCertificate(domain string) error {
 	s.scope.Info("Ensuring ACM certificate is deleted")
-	domain := key.CloudFrontAlias(s.scope.ClusterName(), s.scope.Installation(), s.scope.Region())
 
 	arn, err := s.findCertificateForDomain(domain)
 	if err != nil {

--- a/pkg/aws/services/acm/acm.go
+++ b/pkg/aws/services/acm/acm.go
@@ -72,6 +72,7 @@ func (s *Service) EnsureCertificate(domain string, customerTags map[string]strin
 	return output.CertificateArn, nil
 }
 
+// IsCertificateIssued checks if an ACM certificate is issued.
 func (s *Service) IsCertificateIssued(arn string) (bool, error) {
 	s.scope.Info("Checking status of ACM certificate")
 
@@ -85,6 +86,7 @@ func (s *Service) IsCertificateIssued(arn string) (bool, error) {
 	return *output.Certificate.Status == acm.CertificateStatusIssued, nil
 }
 
+// IsValidated checks wheter an ACM certificate's ownership is already validated or not.
 func (s *Service) IsValidated(arn string) (bool, error) {
 	output, err := s.Client.DescribeCertificate(&acm.DescribeCertificateInput{
 		CertificateArn: aws.String(arn),
@@ -96,6 +98,7 @@ func (s *Service) IsValidated(arn string) (bool, error) {
 	return *output.Certificate.DomainValidationOptions[0].ValidationStatus == acm.DomainStatusSuccess, nil
 }
 
+// GetValidationCNAME returns a CNAME record that needs to be created in order for automated domain ownership validation to work.
 func (s *Service) GetValidationCNAME(arn string) (*route53.CNAME, error) {
 	output, err := s.Client.DescribeCertificate(&acm.DescribeCertificateInput{
 		CertificateArn: aws.String(arn),

--- a/pkg/aws/services/acm/error.go
+++ b/pkg/aws/services/acm/error.go
@@ -1,0 +1,7 @@
+package acm
+
+import "github.com/giantswarm/microerror"
+
+var domainValidationDnsRecordNotFound = &microerror.Error{
+	Kind: "domainValidationDnsRecordNotFound",
+}

--- a/pkg/aws/services/acm/service.go
+++ b/pkg/aws/services/acm/service.go
@@ -1,0 +1,21 @@
+package acm
+
+import (
+	"github.com/aws/aws-sdk-go/service/acm/acmiface"
+
+	"github.com/giantswarm/irsa-operator/pkg/aws/scope"
+)
+
+// Service holds a collection of interfaces.
+type Service struct {
+	scope  scope.ACMScope
+	Client acmiface.ACMAPI
+}
+
+// NewService returns a new service given the Cloudfront api client.
+func NewService(clusterScope scope.IAMScope) *Service {
+	return &Service{
+		scope:  clusterScope,
+		Client: scope.NewACMClient(clusterScope, clusterScope.ARN(), clusterScope.Cluster()),
+	}
+}

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -99,19 +99,3 @@ func GetCustomerTags(cluster *capi.Cluster) map[string]string {
 func CloudFrontDistributionComment(clusterID string) string {
 	return fmt.Sprintf("Created by irsa-operator for cluster %s", clusterID)
 }
-
-func CloudFrontAlias(clusterID string, installation string, region string) string {
-	return fmt.Sprintf("irsa.%s", BaseDomain(clusterID, installation, region))
-}
-
-func BaseDomain(clusterID string, installation string, region string) string {
-	return fmt.Sprintf("%s.k8s.%s.%s.aws.gigantic.io", clusterID, installation, region)
-}
-
-func EnsureTrailingDot(domain string) string {
-	if strings.HasSuffix(domain, ".") {
-		return domain
-	}
-
-	return fmt.Sprintf("%s.", domain)
-}

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -99,3 +99,19 @@ func GetCustomerTags(cluster *capi.Cluster) map[string]string {
 func CloudFrontDistributionComment(clusterID string) string {
 	return fmt.Sprintf("Created by irsa-operator for cluster %s", clusterID)
 }
+
+func CloudFrontAlias(clusterID string, installation string, region string) string {
+	return fmt.Sprintf("irsa.%s", BaseDomain(clusterID, installation, region))
+}
+
+func BaseDomain(clusterID string, installation string, region string) string {
+	return fmt.Sprintf("%s.k8s.%s.%s.aws.gigantic.io", clusterID, installation, region)
+}
+
+func EnsureTrailingDot(domain string) string {
+	if strings.HasSuffix(domain, ".") {
+		return domain
+	}
+
+	return fmt.Sprintf("%s.", domain)
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1546

This PR adds a new `acm` service that's still unused. It will be used in following PRs to create acm certificates to be used in cloudfront when using a custom DNS name

## Checklist

- [x] Update changelog in CHANGELOG.md.
