### PR TITLE
improve oidc provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve `oidc` service in order to recreate the OIDC provider on AWS when any config is changed.
 - Improve `cloudfront` service in order to update the cloudfront distribution on AWS when any config is changed.
+- Allow having multiple URLs in the `oidc` service.
 
 ## [0.8.5] - 2022-11-09
 

--- a/pkg/aws/services/iam/oidc.go
+++ b/pkg/aws/services/iam/oidc.go
@@ -28,58 +28,93 @@ func (s *Service) EnsureOIDCProviders(identityProviderURLs []string, clientID st
 			return err
 		}
 
-	arn, existing, err := s.findOIDCProvider()
-	if err != nil {
-		return microerror.Mask(err)
-	}
+		// Check if one of the providers is already using the right URL.
+		found := false
+		for arn, existing := range providers {
+			if util.EnsureHTTPS(*existing.Url) == util.EnsureHTTPS(identityProviderURL) {
+				// Check if values are up to date.
+				if len(existing.ThumbprintList) != 1 || !strings.EqualFold(*existing.ThumbprintList[0], strings.ToLower(tp)) ||
+					len(existing.ClientIDList) != 1 || *existing.ClientIDList[0] != clientID {
 
-	if existing != nil {
-		// Check if values are up to date.
-		if fmt.Sprintf("https://%s", *existing.Url) != identityProviderURL ||
-			len(existing.ThumbprintList) != 1 || !strings.EqualFold(*existing.ThumbprintList[0], strings.ToLower(tp)) ||
-			len(existing.ClientIDList) != 1 || *existing.ClientIDList[0] != clientID {
-
-			s.scope.Info("OIDCProvider needs to be replaced")
-			s.scope.Info("Deleting old OIDCProvider")
-			_, err = s.Client.DeleteOpenIDConnectProvider(&iam.DeleteOpenIDConnectProviderInput{OpenIDConnectProviderArn: aws.String(arn)})
-			if err != nil {
-				return microerror.Mask(err)
+					s.scope.Info(fmt.Sprintf("OIDCProvider for URL %s needs to be replaced", identityProviderURL))
+					s.scope.Info("Deleting OIDCProvider")
+					_, err = s.Client.DeleteOpenIDConnectProvider(&iam.DeleteOpenIDConnectProviderInput{OpenIDConnectProviderArn: aws.String(arn)})
+					if err != nil {
+						return microerror.Mask(err)
+					}
+					s.scope.Info("Deleted OIDCProvider")
+				} else {
+					found = true
+					break
+				}
 			}
-			s.scope.Info("Deleted old OIDCProvider")
-		} else {
-			s.scope.Info("OIDCProvider already exists and is up to date")
-			return nil
 		}
-	}
 
-	i := &iam.CreateOpenIDConnectProviderInput{
-		Url:            aws.String(identityProviderURL),
-		ThumbprintList: []*string{aws.String(tp)},
-		ClientIDList:   []*string{aws.String(clientID)},
-	}
+		if found {
+			s.scope.Info(fmt.Sprintf("OIDCProvider for URL %s already exists and is up to date", identityProviderURL))
+			continue
+		}
 
-	_, err = s.Client.CreateOpenIDConnectProvider(i)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	s.scope.Info("Created OIDC provider")
+		s.scope.Info(fmt.Sprintf("Creating OIDCProvider for URL %s", identityProviderURL))
 
+		i := &iam.CreateOpenIDConnectProviderInput{
+			Url:            aws.String(identityProviderURL),
+			ThumbprintList: []*string{aws.String(tp)},
+			ClientIDList:   []*string{aws.String(clientID)},
+		}
+
+		// Add internal and customer tags.
+		{
+			for k, v := range s.internalTags() {
+				tag := &iam.Tag{
+					Key:   aws.String(k),
+					Value: aws.String(v),
+				}
+				i.Tags = append(i.Tags, tag)
+			}
+
+			for k, v := range customerTags {
+				tag := &iam.Tag{
+					Key:   aws.String(k),
+					Value: aws.String(v),
+				}
+				i.Tags = append(i.Tags, tag)
+			}
+		}
+
+		_, err = s.Client.CreateOpenIDConnectProvider(i)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		s.scope.Info(fmt.Sprintf("Created OIDC provider for URL %s", identityProviderURL))
+	}
 	return nil
 }
 
-func (s *Service) findOIDCProvider() (string, *iam.GetOpenIDConnectProviderOutput, error) {
-	s.scope.Info("Looking for existing OIDC provider")
+func (s *Service) internalTags() map[string]string {
+	return map[string]string{
+		key.S3TagOrganization: util.RemoveOrg(s.scope.ClusterNamespace()),
+		key.S3TagCluster:      s.scope.ClusterName(),
+		fmt.Sprintf(key.S3TagCloudProvider, s.scope.ClusterName()): "owned",
+		key.S3TagInstallation: s.scope.Installation(),
+	}
+}
+
+func (s *Service) findOIDCProviders() (map[string]*iam.GetOpenIDConnectProviderOutput, error) {
+	s.scope.Info("Looking for existing OIDC providers")
 	output, err := s.Client.ListOpenIDConnectProviders(&iam.ListOpenIDConnectProvidersInput{})
 	if err != nil {
-		return "", nil, microerror.Mask(err)
+		return nil, microerror.Mask(err)
 	}
+
+	ret := make(map[string]*iam.GetOpenIDConnectProviderOutput, 0)
 
 	for _, providerArn := range output.OpenIDConnectProviderList {
 		p, err := s.Client.GetOpenIDConnectProvider(&iam.GetOpenIDConnectProviderInput{
 			OpenIDConnectProviderArn: providerArn.Arn,
 		})
 		if err != nil {
-			return "", nil, microerror.Mask(err)
+			return nil, microerror.Mask(err)
 		}
 
 		// Check if tags match
@@ -95,55 +130,17 @@ func (s *Service) findOIDCProvider() (string, *iam.GetOpenIDConnectProviderOutpu
 		}
 
 		if installationTagFound && clusterTagFound {
-			s.scope.Info("Found existing OIDC provider")
-			return *providerArn.Arn, p, nil
+			ret[*providerArn.Arn] = p
 		}
 	}
 
-	s.scope.Info("Did not find any OIDC provider")
-
-	return "", nil, nil
-}
-
-func (s *Service) CreateOIDCTags(release *semver.Version, cfDomain, accountID, bucketName, region string, customerTags map[string]string) error {
-	var providerArn string
-	if (key.IsV18Release(release) && !key.IsChina(region)) || (s.scope.MigrationNeeded() && !key.IsChina(region)) {
-		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/%s", key.ARNPrefix(region), accountID, cfDomain)
+	if len(ret) == 0 {
+		s.scope.Info("Did not find any OIDC provider")
 	} else {
-		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/s3.%s.%s/%s", key.ARNPrefix(region), accountID, region, key.AWSEndpoint(region), bucketName)
-	}
-	i := &iam.TagOpenIDConnectProviderInput{
-		OpenIDConnectProviderArn: aws.String(providerArn),
-		Tags: []*iam.Tag{
-			{
-				Key:   aws.String(key.S3TagOrganization),
-				Value: aws.String(util.RemoveOrg(s.scope.ClusterNamespace())),
-			},
-			{
-				Key:   aws.String(key.S3TagCluster),
-				Value: aws.String(s.scope.ClusterName()),
-			},
-			{
-				Key:   aws.String(fmt.Sprintf(key.S3TagCloudProvider, s.scope.ClusterName())),
-				Value: aws.String("owned"),
-			},
-			{
-				Key:   aws.String(key.S3TagInstallation),
-				Value: aws.String(s.scope.Installation()),
-			},
-		},
+		s.scope.Info(fmt.Sprintf("Found %d existing OIDC providers", len(ret)))
 	}
 
-	for k, v := range customerTags {
-		i.Tags = append(i.Tags, &iam.Tag{Key: aws.String(k), Value: aws.String(v)})
-	}
-
-	_, err := s.Client.TagOpenIDConnectProvider(i)
-	if err != nil {
-		return err
-	}
-	s.scope.Info("Created tags for OIDC provider")
-	return nil
+	return ret, nil
 }
 
 func (s *Service) ListCustomerOIDCTags(release *semver.Version, cfDomain, accountID, bucketName, region string) (map[string]string, error) {
@@ -173,53 +170,30 @@ func (s *Service) ListCustomerOIDCTags(release *semver.Version, cfDomain, accoun
 	return oidcTags, nil
 }
 
-func (s *Service) RemoveOIDCTags(release *semver.Version, cfDomain, accountID, bucketName, region string, tagKeys []string) error {
-	var providerArn string
-	if (key.IsV18Release(release) && !key.IsChina(region)) || (s.scope.MigrationNeeded() && !key.IsChina(region)) {
-		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/%s", key.ARNPrefix(region), accountID, cfDomain)
-	} else {
-		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/s3.%s.%s/%s", key.ARNPrefix(region), accountID, region, key.AWSEndpoint(region), bucketName)
-	}
-	i := &iam.UntagOpenIDConnectProviderInput{
-		OpenIDConnectProviderArn: aws.String(providerArn),
-		TagKeys:                  []*string{},
-	}
-
-	for _, t := range tagKeys {
-		i.TagKeys = append(i.TagKeys, aws.String(t))
-	}
-
-	_, err := s.Client.UntagOpenIDConnectProvider(i)
+func (s *Service) DeleteOIDCProviders() error {
+	providers, err := s.findOIDCProviders()
 	if err != nil {
-		return err
-	}
-	s.scope.Info("Removed tags for OIDC provider")
-	return nil
-}
-
-func (s *Service) DeleteOIDCProvider(release *semver.Version, cfDomain, accountID, bucketName, region string) error {
-	var providerArn string
-	if (key.IsV18Release(release) && !key.IsChina(region)) || (s.scope.MigrationNeeded() && !key.IsChina(region)) {
-		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/%s", key.ARNPrefix(region), accountID, cfDomain)
-	} else {
-		providerArn = fmt.Sprintf("arn:%s:iam::%s:oidc-provider/s3.%s.%s/%s", key.ARNPrefix(region), accountID, region, key.AWSEndpoint(region), bucketName)
-	}
-	i := &iam.DeleteOpenIDConnectProviderInput{
-		OpenIDConnectProviderArn: aws.String(providerArn),
+		return microerror.Mask(err)
 	}
 
-	_, err := s.Client.DeleteOpenIDConnectProvider(i)
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case iam.ErrCodeNoSuchEntityException:
-				s.scope.Info("OIDC provider no longer exists, skipping deletion")
-				return nil
-			}
+	for providerArn := range providers {
+		i := &iam.DeleteOpenIDConnectProviderInput{
+			OpenIDConnectProviderArn: aws.String(providerArn),
 		}
-		return err
+
+		_, err := s.Client.DeleteOpenIDConnectProvider(i)
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				switch aerr.Code() {
+				case iam.ErrCodeNoSuchEntityException:
+					s.scope.Info("OIDC provider no longer exists, skipping deletion")
+					continue
+				}
+			}
+			return err
+		}
+		s.scope.Info("Deleted OIDC provider")
 	}
-	s.scope.Info("Deleted OIDC provider")
 
 	return nil
 }

--- a/pkg/aws/services/iam/oidc.go
+++ b/pkg/aws/services/iam/oidc.go
@@ -15,11 +15,18 @@ import (
 	"github.com/giantswarm/irsa-operator/pkg/util"
 )
 
-func (s *Service) EnsureOIDCProvider(identityProviderURL, clientID string) error {
-	tp, err := caThumbPrint(identityProviderURL)
+func (s *Service) EnsureOIDCProviders(identityProviderURLs []string, clientID string, customerTags map[string]string) error {
+	providers, err := s.findOIDCProviders()
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
+
+	// Ensure there is one provider for each of the URLs
+	for _, identityProviderURL := range identityProviderURLs {
+		tp, err := caThumbPrint(identityProviderURL)
+		if err != nil {
+			return err
+		}
 
 	arn, existing, err := s.findOIDCProvider()
 	if err != nil {

--- a/pkg/irsa/capa/capa.go
+++ b/pkg/irsa/capa/capa.go
@@ -26,7 +26,6 @@ import (
 	"github.com/giantswarm/irsa-operator/pkg/errors"
 	"github.com/giantswarm/irsa-operator/pkg/key"
 	ctrlmetrics "github.com/giantswarm/irsa-operator/pkg/metrics"
-	"github.com/giantswarm/irsa-operator/pkg/util"
 )
 
 type Service struct {
@@ -205,36 +204,13 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			identityProviderURL = fmt.Sprintf("https://%s/%s", s3Endpoint, s.Scope.BucketName())
 		}
 
-		return s.IAM.EnsureOIDCProvider(identityProviderURL, key.STSUrl(s.Scope.Region()))
+		return s.IAM.EnsureOIDCProviders([]string{identityProviderURL}, key.STSUrl(s.Scope.Region()), customerTags)
 	}
 	err = backoff.Retry(createOIDCProvider, b)
 	if err != nil {
 		ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Inc()
 		s.Scope.Logger.Error(err, "failed to create OIDC provider")
 		return err
-	}
-
-	err = s.IAM.CreateOIDCTags(s.Scope.Release(), cfDomain, s.Scope.AccountID(), s.Scope.BucketName(), s.Scope.Region(), customerTags)
-	if err != nil {
-		ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Inc()
-		s.Scope.Logger.Error(err, "failed to create tags")
-		return err
-	}
-
-	oidcTags, err := s.IAM.ListCustomerOIDCTags(s.Scope.Release(), cfDomain, s.Scope.AccountID(), s.Scope.BucketName(), s.Scope.Region())
-	if err != nil {
-		ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Inc()
-		s.Scope.Logger.Error(err, "failed to list OIDC provider tags")
-		return err
-	}
-
-	if diff := util.MapsDiff(customerTags, oidcTags); diff != nil {
-		s.Scope.Logger.Info("Cluster tags differ from current OIDC tags")
-		if err := s.IAM.RemoveOIDCTags(s.Scope.Release(), cfDomain, s.Scope.AccountID(), s.Scope.BucketName(), s.Scope.Region(), diff); err != nil {
-			ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Inc()
-			s.Scope.Logger.Error(err, "failed to remove tags")
-			return microerror.Mask(err)
-		}
 	}
 
 	ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Set(0)
@@ -256,7 +232,6 @@ func (s *Service) Delete(ctx context.Context) error {
 		return err
 	}
 
-	var cfDomain string
 	var cfDistributionId string
 	var cfOriginAccessIdentityId string
 	cfConfig := &v1.Secret{}
@@ -272,12 +247,11 @@ func (s *Service) Delete(ctx context.Context) error {
 		}
 
 		data := cfConfig.Data
-		cfDomain = string(data["domain"])
 		cfDistributionId = string(data["distributionId"])
 		cfOriginAccessIdentityId = string(data["originAccessIdentityId"])
 	}
 
-	err = s.IAM.DeleteOIDCProvider(s.Scope.Release(), cfDomain, s.Scope.AccountID(), s.Scope.BucketName(), s.Scope.Region())
+	err = s.IAM.DeleteOIDCProviders()
 	if err != nil {
 		ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Inc()
 		s.Scope.Logger.Error(err, "failed to delete OIDC provider")

--- a/pkg/irsa/legacy/legacy.go
+++ b/pkg/irsa/legacy/legacy.go
@@ -198,10 +198,6 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			identityProviderURLs = append(identityProviderURLs, util.EnsureHTTPS(fmt.Sprintf("%s/%s", s3Endpoint, s.Scope.BucketName())))
 		}
 
-		for _, alias := range aliases {
-			identityProviderURLs = append(identityProviderURLs, util.EnsureHTTPS(*alias))
-		}
-
 		return s.IAM.EnsureOIDCProviders(identityProviderURLs, key.STSUrl(s.Scope.Region()), customerTags)
 	}
 	n := func(err error, d time.Duration) {

--- a/pkg/irsa/legacy/legacy.go
+++ b/pkg/irsa/legacy/legacy.go
@@ -190,15 +190,19 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	}
 
 	createOIDCProvider := func() error {
-		var identityProviderURL string
+		var identityProviderURLs []string
 		s3Endpoint := fmt.Sprintf("s3.%s.%s", s.Scope.Region(), key.AWSEndpoint(s.Scope.Region()))
 		if (key.IsV18Release(s.Scope.Release()) && !key.IsChina(s.Scope.Region())) || (s.Scope.MigrationNeeded() && !key.IsChina(s.Scope.Region())) {
-			identityProviderURL = fmt.Sprintf("https://%s", cfDomain)
+			identityProviderURLs = append(identityProviderURLs, util.EnsureHTTPS(cfDomain))
 		} else {
-			identityProviderURL = fmt.Sprintf("https://%s/%s", s3Endpoint, s.Scope.BucketName())
+			identityProviderURLs = append(identityProviderURLs, util.EnsureHTTPS(fmt.Sprintf("%s/%s", s3Endpoint, s.Scope.BucketName())))
 		}
 
-		return s.IAM.EnsureOIDCProvider(identityProviderURL, key.STSUrl(s.Scope.Region()))
+		for _, alias := range aliases {
+			identityProviderURLs = append(identityProviderURLs, util.EnsureHTTPS(*alias))
+		}
+
+		return s.IAM.EnsureOIDCProviders(identityProviderURLs, key.STSUrl(s.Scope.Region()), customerTags)
 	}
 	n := func(err error, d time.Duration) {
 		s.Scope.Logger.Info("level", "warning", "message", fmt.Sprintf("retrying backoff in '%s' due to error", d.String()), "stack", fmt.Sprintf("%#v", err))
@@ -208,29 +212,6 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Inc()
 		s.Scope.Logger.Error(err, "failed to create OIDC provider")
 		return err
-	}
-
-	err = s.IAM.CreateOIDCTags(s.Scope.Release(), cfDomain, s.Scope.AccountID(), s.Scope.BucketName(), s.Scope.Region(), customerTags)
-	if err != nil {
-		ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Inc()
-		s.Scope.Logger.Error(err, "failed to create tags")
-		return err
-	}
-
-	oidcTags, err := s.IAM.ListCustomerOIDCTags(s.Scope.Release(), cfDomain, s.Scope.AccountID(), s.Scope.BucketName(), s.Scope.Region())
-	if err != nil {
-		ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Inc()
-		s.Scope.Logger.Error(err, "failed to list OIDC provider tags")
-		return err
-	}
-
-	if diff := util.MapsDiff(customerTags, oidcTags); diff != nil {
-		s.Scope.Logger.Info("Cluster tags differ from current OIDC tags")
-		if err := s.IAM.RemoveOIDCTags(s.Scope.Release(), cfDomain, s.Scope.AccountID(), s.Scope.BucketName(), s.Scope.Region(), diff); err != nil {
-			ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Inc()
-			s.Scope.Logger.Error(err, "failed to remove tags")
-			return microerror.Mask(err)
-		}
 	}
 
 	ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Set(0)
@@ -252,7 +233,6 @@ func (s Service) Delete(ctx context.Context) error {
 		return err
 	}
 
-	var cfDomain string
 	var cfDistributionId string
 	var cfOriginAccessIdentityId string
 	cfConfig := &v1.ConfigMap{}
@@ -267,12 +247,11 @@ func (s Service) Delete(ctx context.Context) error {
 			return err
 		}
 
-		cfDomain = cfConfig.Data["domain"]
 		cfDistributionId = cfConfig.Data["distributionId"]
 		cfOriginAccessIdentityId = cfConfig.Data["originAccessIdentityId"]
 	}
 
-	err = s.IAM.DeleteOIDCProvider(s.Scope.Release(), cfDomain, s.Scope.AccountID(), s.Scope.BucketName(), s.Scope.Region())
+	err = s.IAM.DeleteOIDCProviders()
 	if err != nil {
 		ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Inc()
 		s.Scope.Logger.Error(err, "failed to delete OIDC provider")

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,27 +1,22 @@
 package util
 
 import (
-	"reflect"
+	"fmt"
 	"strings"
 )
 
-func RemoveOrg(name string) string {
-	return strings.Replace(name, "org-", "", 1)
+func EnsureHTTPS(url string) string {
+	if strings.HasPrefix(url, "https://") {
+		return url
+	}
+
+	url = strings.TrimPrefix(url, "http://")
+
+	return fmt.Sprintf("https://%s", url)
 }
 
-// Get keys if maps differ
-func MapsDiff(m1, m2 map[string]string) []string {
-	equal := reflect.DeepEqual(m1, m2)
-	if equal {
-		return nil
-	}
-	var diff []string
-	for k := range m2 {
-		if _, ok := m1[k]; !ok {
-			diff = append(diff, k)
-		}
-	}
-	return diff
+func RemoveOrg(name string) string {
+	return strings.Replace(name, "org-", "", 1)
 }
 
 func StringInSlice(a string, list []string) bool {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,22 +1,34 @@
 package util
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestMapsDiff(t *testing.T) {
-	m1 := map[string]string{
-		"a": "b",
-		"c": "d",
+func TestEnsureHTTPS(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "Has https",
+			url:  "https://test.io",
+			want: "https://test.io",
+		},
+		{
+			name: "Has http",
+			url:  "http://test.io",
+			want: "https://test.io",
+		},
+		{
+			name: "base dns name",
+			url:  "test.io",
+			want: "https://test.io",
+		},
 	}
-	m2 := map[string]string{
-		"a": "b",
-		"c": "d",
-		"e": "f",
-		"g": "h",
-	}
-	diff := MapsDiff(m1, m2)
-	if len(diff) != 2 {
-		t.Errorf("Expected two diff, got %v", len(diff))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EnsureHTTPS(tt.url); got != tt.want {
+				t.Errorf("EnsureHTTPS() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
During migration from default domain alias to custom domain alias for cloudfront, we can't reliably which of the two domains is in use in a certain cluster.

To be on the safe side, we need to create an oidc provider for both domain names.

This PR enhances the oidc provider, by allowing to create multiple for different URLs.

## Checklist

- [x] Update changelog in CHANGELOG.md.
