### PR TITLE
Use both root CA and leaf certificate thumbprints rather than leaf ce…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve `cloudfront` service in order to update the cloudfront distribution on AWS when any config is changed.
 - Allow having multiple URLs in the `oidc` service.
 - Switch to capa `v1beta1`.
-- Use root CA certificate thumbprint rather than leaf certificate one.
+- Use both root CA and leaf certificate thumbprints rather than leaf certificate one only.
 
 ## [0.8.5] - 2022-11-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow having multiple URLs in the `oidc` service.
 - Switch to capa `v1beta1`.
 - Use both root CA and leaf certificate thumbprints rather than leaf certificate one only.
+- Modify the PSP to allow projected and secret volumes.
 
 ## [0.8.5] - 2022-11-09
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/microerror v0.4.0
 	github.com/go-logr/logr v1.2.2
+	github.com/nhalstead/sprint v1.0.6
 	github.com/peak/s3hash v0.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -801,6 +801,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
+github.com/nhalstead/sprint v1.0.6 h1:/edVOpVR2WjYCDj3AO0Jen9vcEVyagSj39IpNC87ZmY=
+github.com/nhalstead/sprint v1.0.6/go.mod h1:zPZzHyzy9UsMPE1wLBUHRZGz3jnpWMDnAc5HNaRWPNQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/helm/irsa-operator/templates/psp.yaml
+++ b/helm/irsa-operator/templates/psp.yaml
@@ -28,3 +28,6 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
+  volumes:
+    - 'projected'
+    - 'secret'

--- a/pkg/aws/services/iam/oidc.go
+++ b/pkg/aws/services/iam/oidc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/blang/semver"
 	"github.com/giantswarm/microerror"
+	"github.com/nhalstead/sprint"
 
 	"github.com/giantswarm/irsa-operator/pkg/key"
 	"github.com/giantswarm/irsa-operator/pkg/util"
@@ -25,21 +26,22 @@ func (s *Service) EnsureOIDCProviders(identityProviderURLs []string, clientID st
 	}
 
 	thumbprints := make([]*string, 0)
-OUTER:
 	for _, identityProviderURL := range identityProviderURLs {
-		tp, err := caThumbPrint(identityProviderURL)
+		tps, err := caThumbPrints(identityProviderURL)
 		if err != nil {
 			return err
 		}
 
 		// avoid duplicates
-		for _, existing := range thumbprints {
-			if *existing == tp {
-				continue OUTER
+	OUTER:
+		for _, tp := range tps {
+			for _, existing := range thumbprints {
+				if *existing == tp {
+					continue OUTER
+				}
 			}
+			thumbprints = append(thumbprints, &tp)
 		}
-
-		thumbprints = append(thumbprints, &tp)
 	}
 
 	// Ensure there is one provider for each of the URLs
@@ -240,24 +242,41 @@ func (s *Service) DeleteOIDCProviders() error {
 	return nil
 }
 
-func caThumbPrint(ep string) (string, error) {
-	conn, err := tls.Dial("tcp", util.TrimHTTPS(fmt.Sprintf("%s:443", ep)), &tls.Config{}) //nolint:gosec
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-	defer conn.Close()
+func caThumbPrints(ep string) ([]string, error) {
+	ret := make([]string, 0)
 
-	var fingerprint [20]byte
-	// Get the latest Root CA from Certificate Chain
-	for _, peers := range conn.ConnectionState().PeerCertificates {
-		if peers.IsCA {
-			fingerprint = sha1.Sum(peers.Raw) //nolint:gosec
+	// Root CA certificate.
+	{
+		conn, err := tls.Dial("tcp", util.TrimHTTPS(fmt.Sprintf("%s:443", ep)), &tls.Config{}) //nolint:gosec
+		if err != nil {
+			return nil, microerror.Mask(err)
 		}
+		defer conn.Close()
+
+		var fingerprint [20]byte
+		// Get the latest Root CA from Certificate Chain
+		for _, peers := range conn.ConnectionState().PeerCertificates {
+			if peers.IsCA {
+				fingerprint = sha1.Sum(peers.Raw) //nolint:gosec
+			}
+		}
+
+		var buf bytes.Buffer
+		for _, f := range fingerprint {
+			fmt.Fprintf(&buf, "%02X", f)
+		}
+		ret = append(ret, strings.ToLower(buf.String()))
 	}
 
-	var buf bytes.Buffer
-	for _, f := range fingerprint {
-		fmt.Fprintf(&buf, "%02X", f)
+	// Leaf certificate (https://github.com/giantswarm/roadmap/issues/1937).
+	{
+		fp, err := sprint.GetFingerprint(ep, false)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		ret = append(ret, strings.Replace(fp.SHA1, ":", "", -1))
 	}
-	return strings.ToLower(buf.String()), nil
+
+	return ret, nil
 }

--- a/pkg/aws/services/iam/oidc.go
+++ b/pkg/aws/services/iam/oidc.go
@@ -40,7 +40,7 @@ func (s *Service) EnsureOIDCProviders(identityProviderURLs []string, clientID st
 					continue OUTER
 				}
 			}
-			thumbprints = append(thumbprints, &tp)
+			thumbprints = append(thumbprints, &tp) //nolint:gosec
 		}
 	}
 


### PR DESCRIPTION
…rtificate one only.

Before this change:

![before](https://user-images.githubusercontent.com/868430/216771825-62540022-4f3f-4561-98bd-01e9e7c829bd.png)

After this change, the 2 identity providers:

![after(cf)](https://user-images.githubusercontent.com/868430/216771850-c0bf2749-9ad3-432d-bc71-7f7ff492d76b.png)
![after(custom)](https://user-images.githubusercontent.com/868430/216771855-6faca556-984c-4229-b0f0-3b937b5a2288.png)

## Checklist

- [x] Update changelog in CHANGELOG.md.
