### PR TITLE
Disable pushing to aws-app-collection for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,22 +64,26 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      - architect/push-to-app-collection:
-          name: aws-app-collection
-          context: "architect"
-          app_name: "irsa-operator"
-          app_namespace: "giantswarm"
-          app_collection_repo: "aws-app-collection"
-          requires:
-            - push-irsa-operator-to-quay
-            - push-irsa-operator-to-docker
-            - push-irsa-operator-to-aliyun
-            - push-irsa-operator-to-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+
+      # Customers have to adapt to IRSA before vintage can upgrade the operator version
+      # (https://github.com/giantswarm/giantswarm/issues/22689). Therefore, disable automated version bumps for now.
+      # - architect/push-to-app-collection:
+      #     name: aws-app-collection
+      #     context: "architect"
+      #     app_name: "irsa-operator"
+      #     app_namespace: "giantswarm"
+      #     app_collection_repo: "aws-app-collection"
+      #     requires:
+      #       - push-irsa-operator-to-quay
+      #       - push-irsa-operator-to-docker
+      #       - push-irsa-operator-to-aliyun
+      #       - push-irsa-operator-to-app-catalog
+      #     filters:
+      #       branches:
+      #         ignore: /.*/
+      #       tags:
+      #         only: /^v.*/
+
       - architect/push-to-app-collection:
           context: architect
           name: push-to-capa-app-collection
@@ -94,4 +98,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
-

--- a/pkg/aws/services/s3/bucket.go
+++ b/pkg/aws/services/s3/bucket.go
@@ -111,7 +111,7 @@ func (s *Service) DeleteBucket(bucketName string) error {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			case s3.ErrCodeNoSuchBucket:
-				s.scope.Info("Bucket do not exist, continue with deletion", "bucket", bucketName)
+				s.scope.Info("Bucket does not exist, continue with deletion", "bucket", bucketName)
 				return nil
 			}
 		}

--- a/pkg/aws/services/s3/object.go
+++ b/pkg/aws/services/s3/object.go
@@ -122,7 +122,7 @@ func (s *Service) DeleteFiles(bucketName string) error {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			case s3.ErrCodeNoSuchBucket:
-				s.scope.Info("Bucket do not exist, continue with deletion", "bucket", bucketName)
+				s.scope.Info("Bucket does not exist, continue with deletion", "bucket", bucketName)
 				return nil
 			case s3.ErrCodeNoSuchKey:
 				s.scope.Info("Files do not exist, continue with deletion", "bucket", bucketName)


### PR DESCRIPTION
Unblocks https://github.com/giantswarm/roadmap/issues/1832, related to https://github.com/giantswarm/giantswarm/issues/22689.

As discussed in [chat](https://gigantic.slack.com/archives/C02JTRT152L/p1675840504496439), let's unblock Hydra's work on CAPA. For live customers on the vintage product, we avoid bumping the deployed version. For CAPA, we can then tag a release and go ahead – we require the type change from v1alphaX to v1beta1 that is already merged but unreleased.

Plus minor, unrelated typo fix.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
