### PR TITLE
Add timeout for getting TLS connection to identity provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-
 ## [Unreleased]
 
 ### Changed
@@ -15,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add finalizer before reconciling
 - CAPA: Avoid deletion reconciliation if finalizer is already gone (busy loop)
 - CAPA: Look up `AWSClusterRoleIdentity` by the correct reference field instead of assuming it is named like the cluster or dangerously falling back to `default`
+- Add timeout for getting TLS connection to identity provider
 
 ## [0.9.0] - 2023-02-08
 


### PR DESCRIPTION
I had a case where irsa-operator could not reach the CloudFront distribution host (example: `d108796tqr8nbj.cloudfront.net:443`). The call hung for a very long time, blocking reconciliation of any further `AWSCluster` objects since we only use 1 thread ([MaxConcurrentReconciles](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#Options) defaults to 1).

## Checklist

- [x] Update changelog in CHANGELOG.md.
