### PR TITLE
Fix hardcoding release version to 20.0.0-alpha1 for CAPI clusters to ensure the correct bucket name is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix hardcoding release version to 20.0.0-alpha1 for CAPI clusters to ensure the correct bucket name is used. In 0.10.0, this did not work and by mistake, another bucket with the old naming was created and reconciled.
+
 ## [0.10.0] - 2023-02-21
 
 ### Changed

--- a/controllers/capa_controller.go
+++ b/controllers/capa_controller.go
@@ -98,7 +98,7 @@ func (r *CAPAClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		Installation:     r.Installation,
 		Region:           cluster.Spec.Region,
 		// This is a hack to allow CAPI clusters to drop the 'release.giantswarm.io/version' label.
-		ReleaseVersion: "v20.0.0-alpha1",
+		ReleaseVersion: "20.0.0-alpha1",
 		SecretName:     key.SecretName(cluster.Name),
 
 		Logger:  logger,

--- a/pkg/aws/scope/cluster.go
+++ b/pkg/aws/scope/cluster.go
@@ -76,6 +76,11 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 		params.Logger = klogr.New()
 	}
 
+	releaseSemver, err := semver.Parse(params.ReleaseVersion)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse release version %q", params.ReleaseVersion)
+	}
+
 	session, err := sessionForRegion(params.Region)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create aws session")
@@ -103,6 +108,7 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 		migration:        params.Migration,
 		region:           params.Region,
 		releaseVersion:   params.ReleaseVersion,
+		releaseSemver:    releaseSemver,
 		secretName:       params.SecretName,
 
 		Logger:  params.Logger,
@@ -123,6 +129,7 @@ type ClusterScope struct {
 	migration        bool
 	region           string
 	releaseVersion   string
+	releaseSemver    semver.Version
 	secretName       string
 
 	logr.Logger
@@ -190,8 +197,7 @@ func (s *ClusterScope) ReleaseVersion() string {
 
 // Release returns the semver version of the AWS cluster object.
 func (s *ClusterScope) Release() *semver.Version {
-	version, _ := semver.New(s.ReleaseVersion())
-	return version
+	return &s.releaseSemver
 }
 
 // SecretName returns the name of the OIDC secret from the cluster.

--- a/pkg/aws/scope/cluster.go
+++ b/pkg/aws/scope/cluster.go
@@ -76,7 +76,8 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 		params.Logger = klogr.New()
 	}
 
-	releaseSemver, err := semver.Parse(params.ReleaseVersion)
+	// `ParseTolerant` instead of `Parse` in case we ever mistakenly use the `v` version prefix or other non-strict format
+	releaseSemver, err := semver.ParseTolerant(params.ReleaseVersion)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse release version %q", params.ReleaseVersion)
 	}


### PR DESCRIPTION
The `v` prefix means that `semver.{New,Parse}` would fail since it's not strictly semver-formatted. But since we swallowed the error, we now have the case that irsa-operator worked with the wrong bucket name, creating lots of unwanted buckets for clusters where 0.10.0 got installed (see https://github.com/giantswarm/roadmap/issues/2059 for the needed cleanup). This change fixes the version parsing. Code isn't really made to be tested, and I postponed such refactoring because this bug blocked us while creating a new MC (https://github.com/giantswarm/roadmap/issues/2023).

## Checklist

- [x] Update changelog in CHANGELOG.md.
