### PR TITLE
Create CNAME record in the private DNS zone as well in legacy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Create CNAME record in the private DNS zone as well in legacy.
+
 ## [0.11.1] - 2023-03-09
 
 ### Fixed

--- a/pkg/aws/services/route53/route53.go
+++ b/pkg/aws/services/route53/route53.go
@@ -13,7 +13,15 @@ type CNAME struct {
 	Value string
 }
 
-func (s *Service) FindHostedZone(basename string) (string, error) {
+func (s *Service) FindPublicHostedZone(basename string) (string, error) {
+	return s.FindHostedZone(basename, true)
+}
+
+func (s *Service) FindPrivateHostedZone(basename string) (string, error) {
+	return s.FindHostedZone(basename, false)
+}
+
+func (s *Service) FindHostedZone(basename string, public bool) (string, error) {
 	s.scope.Info("Searching route53 hosted zone ID")
 
 	output, err := s.Client.ListHostedZonesByName(&route53.ListHostedZonesByNameInput{
@@ -23,9 +31,9 @@ func (s *Service) FindHostedZone(basename string) (string, error) {
 		return "", microerror.Mask(err)
 	}
 
-	// We return the first public zone
+	// We return the first zone found that matches the basename and is public or not according to the parameter.
 	for _, zone := range output.HostedZones {
-		if !*zone.Config.PrivateZone {
+		if public == !*zone.Config.PrivateZone {
 			return *zone.Id, nil
 		}
 	}

--- a/pkg/aws/services/route53/route53.go
+++ b/pkg/aws/services/route53/route53.go
@@ -14,14 +14,14 @@ type CNAME struct {
 }
 
 func (s *Service) FindPublicHostedZone(basename string) (string, error) {
-	return s.FindHostedZone(basename, true)
+	return s.findHostedZone(basename, true)
 }
 
 func (s *Service) FindPrivateHostedZone(basename string) (string, error) {
-	return s.FindHostedZone(basename, false)
+	return s.findHostedZone(basename, false)
 }
 
-func (s *Service) FindHostedZone(basename string, public bool) (string, error) {
+func (s *Service) findHostedZone(basename string, public bool) (string, error) {
 	s.scope.Info("Searching route53 hosted zone ID")
 
 	output, err := s.Client.ListHostedZonesByName(&route53.ListHostedZonesByNameInput{

--- a/pkg/irsa/capa/capa.go
+++ b/pkg/irsa/capa/capa.go
@@ -149,7 +149,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 				return err
 			}
 
-			hostedZoneID, err = s.Route53.FindHostedZone(baseDomain)
+			hostedZoneID, err = s.Route53.FindPublicHostedZone(baseDomain)
 			if err != nil {
 				ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Inc()
 				s.Scope.Logger.Error(err, "failed to find route53 hosted zone ID")


### PR DESCRIPTION
We need to create the irsa.<base domain> CNAME towards cloudfront in the private DNS zone as well, otherwise trying to resolve the irsa domain from inside the cluster will fail (causes cncf conformance tests to fail)

## Checklist

- [x] Update changelog in CHANGELOG.md.
