### PR TITLE
Fix pagination when deleting certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix pagination when fetching ACM certificates to delete.
+
 ## [0.12.0] - 2023-04-17
 
 ### Fixed

--- a/pkg/aws/services/acm/acm.go
+++ b/pkg/aws/services/acm/acm.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/aws/aws-sdk-go/service/acm/acmiface"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/irsa-operator/pkg/aws/services/route53"
@@ -148,38 +149,38 @@ func (s *Service) DeleteCertificate(domain string) error {
 }
 
 func (s *Service) findCertificateForDomain(domain string) (*string, error) {
-	var existing *acm.ListCertificatesOutput
-	var err error
-
-	// NextToken is the way AWS API performs pagination over results.
-	// If NextToken is not nil, there is another page of results to be requested.
-
-	var nextToken string
-
-	// If existing is nil, means we have to request the very first page of results.
-	for existing == nil || nextToken != "" {
-		if existing != nil && existing.NextToken != nil && *existing.NextToken != "" {
-			nextToken = *existing.NextToken
-		}
-		input := &acm.ListCertificatesInput{}
-		if nextToken != "" {
-			input.NextToken = &nextToken
-		}
-		existing, err = s.Client.ListCertificates(input)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		if len(existing.CertificateSummaryList) == 0 {
-			return nil, nil
-		}
-
-		for _, c := range existing.CertificateSummaryList {
-			if *c.DomainName == domain {
-				return c.CertificateArn, nil
-			}
+	certs := getACMCertificates(s.Client)
+	for _, certificate := range certs {
+		if *certificate.DomainName == domain {
+			return certificate.CertificateArn, nil
 		}
 	}
 
 	return nil, nil
+}
+
+func getACMCertificates(acmClient acmiface.ACMAPI) []*acm.CertificateSummary {
+	certs := []*acm.CertificateSummary{}
+	output, err := acmClient.ListCertificates(&acm.ListCertificatesInput{
+		MaxItems: aws.Int64(100),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	certs = append(certs, output.CertificateSummaryList...)
+
+	// If the response contains `NexToken` we need to keep sending requests including the token to get all results.
+	for output.NextToken != nil && *output.NextToken != "" {
+		output, err = acmClient.ListCertificates(&acm.ListCertificatesInput{
+			MaxItems:  aws.Int64(100),
+			NextToken: output.NextToken,
+		})
+		if err != nil {
+			panic(err)
+		}
+		certs = append(certs, output.CertificateSummaryList...)
+	}
+
+	return certs
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2060

There are currently two problems that I believe share the same root cause. There are several different certificates being created for the same WC. And also certificates that are not being cleaned up after removing a WC.

In both cases I believe the problem is that we only fetch the first page of results when listing certificates, so we don't find the certificate that we want, meaning
- we recreate it because it's missing
- we don't clean it when removing a WC

This PR tries to fix the pagination issue.

## Checklist

- [X] Update changelog in CHANGELOG.md.
