### PR TITLE
Allow using cloudfront alias before v19.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow using Cloudfront Alias before v19.0.0 via annotation `alpha.aws.giantswarm.io/enable-cloudfront-alias`.
+
 ## [0.12.1] - 2023-04-20
 
 ### Fixed

--- a/controllers/legacy_controller.go
+++ b/controllers/legacy_controller.go
@@ -134,19 +134,23 @@ func (r *LegacyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	}
 
+	// Check if Cloudfront alias should be used before v19.0.0
+	_, preCloudfrontAlias := cluster.Annotations[key.IRSAPreCloudfrontAlias]
+
 	// create the cluster scope.
 	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
-		AccountID:        accountID,
-		ARN:              arn,
-		BucketName:       key.BucketName(accountID, cluster.Name),
-		ClusterName:      cluster.Name,
-		ClusterNamespace: cluster.Namespace,
-		ConfigName:       key.ConfigName(cluster.Name),
-		Installation:     r.Installation,
-		Migration:        migration,
-		Region:           cluster.Spec.Provider.Region,
-		ReleaseVersion:   key.Release(cluster),
-		SecretName:       key.SecretName(cluster.Name),
+		AccountID:          accountID,
+		ARN:                arn,
+		BucketName:         key.BucketName(accountID, cluster.Name),
+		ClusterName:        cluster.Name,
+		ClusterNamespace:   cluster.Namespace,
+		ConfigName:         key.ConfigName(cluster.Name),
+		Installation:       r.Installation,
+		Migration:          migration,
+		PreCloudfrontAlias: preCloudfrontAlias,
+		Region:             cluster.Spec.Provider.Region,
+		ReleaseVersion:     key.Release(cluster),
+		SecretName:         key.SecretName(cluster.Name),
 
 		Logger:  logger,
 		Cluster: cluster,

--- a/pkg/aws/scope/cluster.go
+++ b/pkg/aws/scope/cluster.go
@@ -17,18 +17,19 @@ import (
 
 // ClusterScopeParams defines the input parameters used to create a new Scope.
 type ClusterScopeParams struct {
-	AccountID        string
-	ARN              string
-	BucketName       string
-	Cluster          runtime.Object
-	ClusterName      string
-	ClusterNamespace string
-	ConfigName       string
-	Installation     string
-	Migration        bool
-	Region           string
-	ReleaseVersion   string
-	SecretName       string
+	AccountID          string
+	ARN                string
+	BucketName         string
+	Cluster            runtime.Object
+	ClusterName        string
+	ClusterNamespace   string
+	ConfigName         string
+	Installation       string
+	Migration          bool
+	PreCloudfrontAlias bool
+	Region             string
+	ReleaseVersion     string
+	SecretName         string
 
 	Logger  logr.Logger
 	Session awsclient.ConfigProvider
@@ -93,19 +94,20 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 	params.Logger.Info(fmt.Sprintf("assumed role %s", *o.Arn))
 
 	return &ClusterScope{
-		accountID:        params.AccountID,
-		assumeRole:       params.ARN,
-		bucketName:       params.BucketName,
-		cluster:          params.Cluster,
-		clusterName:      params.ClusterName,
-		clusterNamespace: params.ClusterNamespace,
-		configName:       params.ConfigName,
-		installation:     params.Installation,
-		migration:        params.Migration,
-		region:           params.Region,
-		releaseVersion:   params.ReleaseVersion,
-		releaseSemver:    releaseSemver,
-		secretName:       params.SecretName,
+		accountID:          params.AccountID,
+		assumeRole:         params.ARN,
+		bucketName:         params.BucketName,
+		cluster:            params.Cluster,
+		clusterName:        params.ClusterName,
+		clusterNamespace:   params.ClusterNamespace,
+		configName:         params.ConfigName,
+		installation:       params.Installation,
+		migration:          params.Migration,
+		preCloudfrontAlias: params.PreCloudfrontAlias,
+		region:             params.Region,
+		releaseVersion:     params.ReleaseVersion,
+		releaseSemver:      releaseSemver,
+		secretName:         params.SecretName,
 
 		Logr:    params.Logger,
 		session: session,
@@ -114,19 +116,20 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 
 // ClusterScope defines the basic context for an actuator to operate upon.
 type ClusterScope struct {
-	accountID        string
-	bucketName       string
-	assumeRole       string
-	cluster          runtime.Object
-	clusterName      string
-	clusterNamespace string
-	configName       string
-	installation     string
-	migration        bool
-	region           string
-	releaseVersion   string
-	releaseSemver    semver.Version
-	secretName       string
+	accountID          string
+	bucketName         string
+	assumeRole         string
+	cluster            runtime.Object
+	clusterName        string
+	clusterNamespace   string
+	configName         string
+	installation       string
+	migration          bool
+	preCloudfrontAlias bool
+	region             string
+	releaseVersion     string
+	releaseSemver      semver.Version
+	secretName         string
 
 	Logr    logr.Logger
 	session awsclient.ConfigProvider
@@ -183,6 +186,11 @@ func (s *ClusterScope) Installation() string {
 // MigrationNeeded returns if the cluster object needs migration beforehand.
 func (s *ClusterScope) MigrationNeeded() bool {
 	return s.migration
+}
+
+// PreCloudfrontAlias returns if the cloudfront alias should be used before v19.0.0.
+func (s *ClusterScope) PreCloudfrontAlias() bool {
+	return s.preCloudfrontAlias
 }
 
 // Region returns the region of the AWS infrastructure cluster object.

--- a/pkg/irsa/legacy/legacy.go
+++ b/pkg/irsa/legacy/legacy.go
@@ -232,7 +232,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 				}
 			}
 
-			if key.IsV19Release(s.Scope.Release()) {
+			if key.IsV19Release(s.Scope.Release()) || s.Scope.PreCloudfrontAlias() {
 				data["domainAlias"] = *aliases[0]
 			}
 		}

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -16,6 +16,8 @@ const (
 	IRSAAnnotation = "alpha.aws.giantswarm.io/iam-roles-for-service-accounts"
 	// Upgrading existing IRSA clusters witout breaking clusters
 	IRSAMigrationAnnotation = "alpha.aws.giantswarm.io/irsa-migration"
+	// Use Cloudfront alias before v19.0.0
+	IRSAPreCloudfrontAlias = "alpha.aws.giantswarm.io/enable-cloudfront-alias"
 
 	S3TagCloudProvider = "kubernetes.io/cluster/%s"
 	S3TagCluster       = "giantswarm.io/cluster"


### PR DESCRIPTION
Issue: https://github.com/giantswarm/giantswarm/issues/26676

When setting the annotation `alpha.aws.giantswarm.io/enable-cloudfront-alias: ""` on AWSCluster we do allow customers switching to Cloudfront alias before upgrading to v19.x.x.

This means customer need to change their IAM roles trust entity, allowing the Cloudfront alias:

```
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "arn:aws:iam::ROLE_AWSACCOUNT:oidc-provider/CLOUDFRONT_ALTERNATE_DOMAIN"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringEquals": {
                    "CLOUDFRONT_ALTERNATE_DOMAIN:sub": "system:serviceaccount:NAMESPACE:SA_NAME"
                }
            }
        }
```

## Checklist

- [x] Update changelog in CHANGELOG.md.