### PR TITLE
remove-logic-for-private-capa-cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update Go dependencies to fix vulnerability in `golang.org/x/net v0.9.0`
+- Use `irsa.domain.gigantic.io` alias for all CAPA clusters including proxy based clusters.
 
 ## [0.19.0] - 2023-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update Go dependencies to fix vulnerability in `golang.org/x/net v0.9.0`
-- Use `irsa.domain.gigantic.io` alias for all CAPA clusters including proxy based clusters.
+- Use `irsa.<baseDomain>` alias for all CAPA clusters including proxy based clusters.
 
 ## [0.19.0] - 2023-08-03
 

--- a/pkg/irsa/capa/capa.go
+++ b/pkg/irsa/capa/capa.go
@@ -423,9 +423,5 @@ func (s *Service) ServiceAccountSecret(ctx context.Context) (*rsa.PrivateKey, er
 }
 
 func (s *Service) getCloudFrontAliasDomain() string {
-	if s.Scope.VPCMode() != "private" {
-		return key.CloudFrontAlias(s.Scope.BaseDomain())
-	}
-
-	return ""
+	return key.CloudFrontAlias(s.Scope.BaseDomain())
 }


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/2690

necessary to get goat working on public domain