### PR TITLE
Increase caching duration for DNS entries, CAPA: Skip reconciliation if paused annotation exists on `AWSCluster` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - List many hosted zones at once in one Route53 request and cache all returned zones. This reduces the number of Route53 requests and therefore avoids rate limit (throttling) errors.
+- CAPA: Skip reconciliation if paused annotation exists on `AWSCluster` object
 
 ## [0.23.2] - 2024-01-29
 

--- a/controllers/capa_controller.go
+++ b/controllers/capa_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/tools/record"
 	capa "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,6 +76,11 @@ func (r *CAPAClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	cluster := &capa.AWSCluster{}
 	if err := r.Get(ctx, req.NamespacedName, cluster); err != nil {
 		return ctrl.Result{}, microerror.Mask(client.IgnoreNotFound(err))
+	}
+
+	if annotations.HasPaused(cluster) {
+		logger.Info("AWSCluster is marked as paused, skipping")
+		return ctrl.Result{}, nil
 	}
 
 	awsClusterRoleIdentity := &capa.AWSClusterRoleIdentity{}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29610

Two unrelated changes in one PR, sorry.

## Checklist

- [x] Update changelog in CHANGELOG.md.
