### PR TITLE
Avoid unnecessary `ChangeResourceRecordSets` upsert requests if the same update was recently done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Avoid unnecessary `ChangeResourceRecordSets` upsert requests if the same update was recently done. This further avoids hitting the AWS Route53 rate limit.
+
 ## [0.24.0] - 2024-01-30
 
 ### Changed


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29610

I also removed the _region_ from cache keys, since Route53 doesn't have the concept of regions. The ARN is enough to distinguish cache keys here (i.e. per AWS account).

## Checklist

- [x] Update changelog in CHANGELOG.md.
