### PR TITLE
add-toleration-for-unitialized-nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
+- Add node affinity to prefer scheduling CAPI pods to control-plane nodes.
+
 ## [0.26.3] - 2024-04-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
+- Add taint toleration.
 - Add node affinity to prefer scheduling CAPI pods to control-plane nodes.
 
 ## [0.26.3] - 2024-04-10

--- a/helm/irsa-operator/templates/deployment.yaml
+++ b/helm/irsa-operator/templates/deployment.yaml
@@ -21,6 +21,19 @@ spec:
       labels:
     {{- include "labels.selector" . | nindent 8 }}
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            weight: 10
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            weight: 10
       serviceAccountName: {{ include "resource.default.name"  . }}
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
@@ -52,6 +65,12 @@ spec:
         - mountPath: /home/.aws
           name: credentials
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: "node.cluster.x-k8s.io/uninitialized"
+        operator: "Exists"
       volumes:
       - name: credentials
         secret:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/30433


### Changed

- Add taint toleration.
- Add node affinity to prefer scheduling CAPI pods to control-plane nodes.

