### PR TITLE
Don't try to reconcile EKS clusters that don't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't try to reconcile EKS clusters that don't exist anymore on the k8s API.
+
 ## [0.27.2] - 2024-06-06
 
 ### Fixed

--- a/controllers/eks_controller.go
+++ b/controllers/eks_controller.go
@@ -62,7 +62,7 @@ func (r *EKSClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	eksCluster := &eks.AWSManagedControlPlane{}
 	if err = r.Get(ctx, req.NamespacedName, eksCluster); err != nil {
-		return ctrl.Result{}, microerror.Mask(err)
+		return ctrl.Result{}, microerror.Mask(client.IgnoreNotFound(err))
 	}
 
 	awsClusterRoleIdentity := &capa.AWSClusterRoleIdentity{}


### PR DESCRIPTION
If there is an error trying to reconcile an EKS cluster the controller will re queue this reconciliation event. If the cluster is removed in between, the controller will keep erroring and requeing  ad infinitum. If the cluster no longer exists, it's safe to ignore the reconciliation event, as we can't really do anything.

## Checklist

- [X] Update changelog in CHANGELOG.md.
