### PR TITLE
Consider `giantswarm.io/keep-irsa` label on the `AWSCluster` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Vintage AWS: Consider `giantswarm.io/keep-irsa` label on the `AWSCluster` object. Previously, we checked on the `Cluster` object, but if that was already independently deleted during a cluster migration, a bug led to deleting the IRSA cloud resources (incl. OIDC provider). The [cluster migration CLI now automatically puts this label on the `AWSCluster` object](https://github.com/giantswarm/capi-migration-cli/pull/119).
+
 ## [0.29.0] - 2024-07-04
 
 ### Added
 
-- Prevent deletion of IRSA related components with "giantswarm.io/keep-irsa" label.
+- Vintage AWS: Prevent deletion of IRSA related components with `giantswarm.io/keep-irsa` label.
 
 ### Fixed
 

--- a/controllers/legacy_controller.go
+++ b/controllers/legacy_controller.go
@@ -171,7 +171,7 @@ func (r *LegacyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, nil
 		}
 
-		err := irsaService.Delete(ctx)
+		err := irsaService.Delete(ctx, cluster)
 		if err != nil {
 			return ctrl.Result{}, microerror.Mask(err)
 		}

--- a/pkg/key/key_test.go
+++ b/pkg/key/key_test.go
@@ -3,6 +3,8 @@ package key
 import (
 	"testing"
 
+	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -59,6 +61,57 @@ func TestBaseDomain(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("BaseDomain() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKeepOnDeletion(t *testing.T) {
+	tests := []struct {
+		name       string
+		awsCluster *infrastructurev1alpha3.AWSCluster
+		wantToKeep bool
+	}{
+		{
+			name: "No labels",
+			awsCluster: &infrastructurev1alpha3.AWSCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"hey": "ho",
+					},
+				},
+			},
+			wantToKeep: false,
+		},
+		{
+			name: "Other label",
+			awsCluster: &infrastructurev1alpha3.AWSCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"hey": "ho",
+					},
+				},
+			},
+			wantToKeep: false,
+		},
+		{
+			name: "With 'keep' label",
+			awsCluster: &infrastructurev1alpha3.AWSCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"hey":                     "ho",
+						"giantswarm.io/keep-irsa": "",
+					},
+				},
+			},
+			wantToKeep: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := KeepOnDeletion(tt.awsCluster)
+			if got != tt.wantToKeep {
+				t.Errorf("KeepOnDeletion() got = %v, want %v", got, tt.wantToKeep)
 			}
 		})
 	}


### PR DESCRIPTION
Consider the label on `AWSCluster` as added via https://github.com/giantswarm/capi-migration-cli/pull/119. Fixes accidental removal of the OIDC provider once we remove the vintage CRs `Cluster` and `AWSCluster` (of which only the latter is controlled by irsa-operator by a finalizer).

## Checklist

- [x] Update changelog in CHANGELOG.md.
