### PR TITLE
Conditionally delete CloudFront domain OIDC provider `<random>.cloudfront.net` for vintage AWS clusters based on `AWSCluster` annotation `alpha.aws.giantswarm.io/irsa-keep-cloudfront-oidc-provider={true,false}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Conditionally delete CloudFront domain OIDC provider `<random>.cloudfront.net` for vintage AWS clusters based on `AWSCluster` annotation `alpha.aws.giantswarm.io/irsa-keep-cloudfront-oidc-provider={true,false}`
+
 ## [0.29.4] - 2024-08-21
 
 ### Fixed

--- a/pkg/aws/scope/cluster.go
+++ b/pkg/aws/scope/cluster.go
@@ -18,22 +18,23 @@ import (
 
 // ClusterScopeParams defines the input parameters used to create a new Scope.
 type ClusterScopeParams struct {
-	AccountID          string
-	ARN                string
-	BaseDomain         string
-	BucketName         string
-	Cache              *gocache.Cache
-	Cluster            runtime.Object
-	ClusterName        string
-	ClusterNamespace   string
-	ConfigName         string
-	Installation       string
-	Migration          bool
-	PreCloudfrontAlias bool
-	Region             string
-	ReleaseVersion     string
-	SecretName         string
-	VPCMode            string
+	AccountID                  string
+	ARN                        string
+	BaseDomain                 string
+	BucketName                 string
+	Cache                      *gocache.Cache
+	Cluster                    runtime.Object
+	ClusterName                string
+	ClusterNamespace           string
+	ConfigName                 string
+	Installation               string
+	KeepCloudFrontOIDCProvider bool
+	Migration                  bool
+	PreCloudfrontAlias         bool
+	Region                     string
+	ReleaseVersion             string
+	SecretName                 string
+	VPCMode                    string
 
 	Logger  logr.Logger
 	Session awsclient.ConfigProvider
@@ -101,23 +102,24 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 	params.Logger.Info(fmt.Sprintf("assumed role %s", *o.Arn))
 
 	return &ClusterScope{
-		accountID:          params.AccountID,
-		assumeRole:         params.ARN,
-		baseDomain:         params.BaseDomain,
-		bucketName:         params.BucketName,
-		cache:              params.Cache,
-		cluster:            params.Cluster,
-		clusterName:        params.ClusterName,
-		clusterNamespace:   params.ClusterNamespace,
-		configName:         params.ConfigName,
-		installation:       params.Installation,
-		migration:          params.Migration,
-		preCloudfrontAlias: params.PreCloudfrontAlias,
-		region:             params.Region,
-		releaseVersion:     params.ReleaseVersion,
-		releaseSemver:      releaseSemver,
-		secretName:         params.SecretName,
-		vpcMode:            params.VPCMode,
+		accountID:                  params.AccountID,
+		assumeRole:                 params.ARN,
+		baseDomain:                 params.BaseDomain,
+		bucketName:                 params.BucketName,
+		cache:                      params.Cache,
+		cluster:                    params.Cluster,
+		clusterName:                params.ClusterName,
+		clusterNamespace:           params.ClusterNamespace,
+		configName:                 params.ConfigName,
+		installation:               params.Installation,
+		keepCloudFrontOIDCProvider: params.KeepCloudFrontOIDCProvider,
+		migration:                  params.Migration,
+		preCloudfrontAlias:         params.PreCloudfrontAlias,
+		region:                     params.Region,
+		releaseVersion:             params.ReleaseVersion,
+		releaseSemver:              releaseSemver,
+		secretName:                 params.SecretName,
+		vpcMode:                    params.VPCMode,
 
 		Logr:    params.Logger,
 		session: session,
@@ -126,23 +128,24 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 
 // ClusterScope defines the basic context for an actuator to operate upon.
 type ClusterScope struct {
-	accountID          string
-	baseDomain         string
-	bucketName         string
-	assumeRole         string
-	cache              *gocache.Cache
-	cluster            runtime.Object
-	clusterName        string
-	clusterNamespace   string
-	configName         string
-	installation       string
-	migration          bool
-	preCloudfrontAlias bool
-	region             string
-	releaseVersion     string
-	releaseSemver      semver.Version
-	secretName         string
-	vpcMode            string
+	accountID                  string
+	baseDomain                 string
+	bucketName                 string
+	assumeRole                 string
+	cache                      *gocache.Cache
+	cluster                    runtime.Object
+	clusterName                string
+	clusterNamespace           string
+	configName                 string
+	installation               string
+	keepCloudFrontOIDCProvider bool
+	migration                  bool
+	preCloudfrontAlias         bool
+	region                     string
+	releaseVersion             string
+	releaseSemver              semver.Version
+	secretName                 string
+	vpcMode                    string
 
 	Logr    logr.Logger
 	session awsclient.ConfigProvider
@@ -213,6 +216,12 @@ func (s *ClusterScope) ConfigName() string {
 // Installation returns the name of the installation where the cluster object is located.
 func (s *ClusterScope) Installation() string {
 	return s.installation
+}
+
+// KeepCloudFrontOIDCProvider returns whether the `<random>.cloudfront.net` OIDC provider
+// domain should be created/kept (true) or deleted (false)
+func (s *ClusterScope) KeepCloudFrontOIDCProvider() bool {
+	return s.keepCloudFrontOIDCProvider
 }
 
 // MigrationNeeded returns if the cluster object needs migration beforehand.

--- a/pkg/irsa/capa/capa.go
+++ b/pkg/irsa/capa/capa.go
@@ -324,7 +324,7 @@ func (s *Service) Reconcile(ctx context.Context, outRequeueAfter *time.Duration)
 			identityProviderURLs = append(identityProviderURLs, util.EnsureHTTPS(*alias))
 		}
 
-		return s.IAM.EnsureOIDCProviders(identityProviderURLs, key.STSUrl(s.Scope.Region()), awsCluster.Spec.AdditionalTags)
+		return s.IAM.EnsureOIDCProviders(identityProviderURLs, []string{}, key.STSUrl(s.Scope.Region()), awsCluster.Spec.AdditionalTags)
 	}
 	err = backoff.Retry(createOIDCProvider, b)
 	if err != nil {

--- a/pkg/irsa/eks/eks.go
+++ b/pkg/irsa/eks/eks.go
@@ -48,7 +48,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		return microerror.Mask(err)
 	}
 
-	err = s.IAM.EnsureOIDCProviders(identityProviderURLs, key.STSUrl(s.Scope.Region()), cluster.Spec.AdditionalTags)
+	err = s.IAM.EnsureOIDCProviders(identityProviderURLs, []string{}, key.STSUrl(s.Scope.Region()), cluster.Spec.AdditionalTags)
 	if err != nil {
 		ctrlmetrics.Errors.WithLabelValues(s.Scope.Installation(), s.Scope.AccountID(), s.Scope.ClusterName(), s.Scope.ClusterNamespace()).Inc()
 		s.Scope.Logger().Error(err, "failed to create OIDC provider")

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -17,9 +17,16 @@ const (
 	// Upgrading existing IRSA clusters witout breaking clusters
 	IRSAMigrationAnnotation = "alpha.aws.giantswarm.io/irsa-migration"
 	// Use Cloudfront alias before v19.0.0
-	IRSAPreCloudfrontAlias = "alpha.aws.giantswarm.io/enable-cloudfront-alias"
-	// Keep IRSA annotation
+	IRSAPreCloudfrontAliasAnnotation = "alpha.aws.giantswarm.io/enable-cloudfront-alias"
+	// Keep IRSA label
 	KeepIRSALabel = "giantswarm.io/keep-irsa"
+	// Whether to create/keep the `<random>.cloudfront.net` OIDC provider. Only used for vintage. Defaults
+	// to `true` for backward compatibility, and only the values `true` or `false` are allowed.
+	// If a single cluster doesn't have any IAM roles using the `<random>.cloudfront.net` OIDC provider domain,
+	// this annotation can be set to `false` in order to make the operator delete that OIDC provider.
+	// The CloudFront distribution is of course not deleted, since it also hosts the OIDC configuration for the
+	// predictable `irsa.<basedomain>` OIDC provider (which customers should use).
+	KeepCloudFrontOIDCProviderAnnotation = "alpha.aws.giantswarm.io/irsa-keep-cloudfront-oidc-provider"
 
 	S3TagCloudProvider = "kubernetes.io/cluster/%s"
 	S3TagCluster       = "giantswarm.io/cluster"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31546. With this, we can annotate each cluster where the old OIDC provider domain should be removed from AWS IAM OIDC providers. By default, it's kept, so we don't risk that a customer still references the provider. We can bring down the number of providers in an account easily this way (limited to 100).

Tested manually, and the annotation can quickly be toggled from `"true"`/`""` to `false` and back without issues (easy rollback).

I'm also renaming the variable `cluster` (of type `AWSCluster`!) to `awsCluster`. Minor rename to an annotation constant variable name as well.

## Checklist

- [x] Update changelog in CHANGELOG.md.
