### PR TITLE
Don't fail when deleting cluster if 'cluster-values' CM is gone trying to delete finalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't fail when reconciling cluster deletion if `cluster-values` configmap is gone while trying to remove its finalizer.
+
 ## [0.33.1] - 2025-06-11
 
 ### Changed


### PR DESCRIPTION
The controller was failing to reconcile when the `cluster-values` configmap was already gone
```
{"level":"error","ts":"2025-06-25T14:50:32Z","msg":"Reconciler error","controller":"awscluster","controllerGroup":"infrastructure.cluster.x-k8s.io","controllerKind":"AWSCluster","AWSCluster":{"name":"t-iy4z2b10agnzwc83w0","namespace":"org-t-sngnnyw4fwtxj9qc3k"},"namespace":"org-t-sngnnyw4fwtxj9qc3k","name":"t-iy4z2b10agnzwc83w0","reconcileID":"61e0cc6a-4035-4d5d-ba75-2073b70c67be","error":"ConfigMap \"t-iy4z2b10agnzwc83w0-cluster-values\" not found","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.6/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.6/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.6/pkg/internal/controller/controller.go:224"}
```

## Checklist

- [X] Update changelog in CHANGELOG.md.
